### PR TITLE
Release 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - if [ "${EXTRA_PACKAGES}" != "" ]; then sudo apt-get -f -y install ${EXTRA_PACKAGES}; fi
   - pip3 install --user -U colcon-common-extensions
   - pip3 install --user xmlrunner
-  - pip2 install --user pygccxml https://bitbucket.org/ompl/pyplusplus/get/1.8.1.zip xmlrunner
+  - pip2 install --user pygccxml pyplusplus xmlrunner
 
 env:
   global:

--- a/ad_map_access/generated/CMakeLists.txt
+++ b/ad_map_access/generated/CMakeLists.txt
@@ -14,7 +14,7 @@
 ##
 
 cmake_minimum_required(VERSION 3.5)
-project(ad_map_access VERSION 2.1.0)
+project(ad_map_access VERSION 2.2.0)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -47,7 +47,7 @@ get_target_property(AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS ad_map_opendr
 list(APPEND INCLUDE_DIRS ${AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS})
 list(APPEND LIBRARIES ad_map_opendrive_reader)
 
-find_package(ad_physics 2.1.0 REQUIRED CONFIG)
+find_package(ad_physics 2.2.0 REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 
 add_library(${PROJECT_NAME}

--- a/ad_map_access/generated/cmake/Config.cmake.in
+++ b/ad_map_access/generated/cmake/Config.cmake.in
@@ -30,7 +30,7 @@ get_target_property(AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS ad_map_opendr
 list(APPEND INCLUDE_DIRS ${AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS})
 list(APPEND LIBRARIES ad_map_opendrive_reader)
 
-find_dependency(ad_physics 2.1.0)
+find_dependency(ad_physics 2.2.0)
 find_dependency(spdlog)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/ad_map_access/generated/include/ad/map/landmark/Landmark.hpp
+++ b/ad_map_access/generated/include/ad/map/landmark/Landmark.hpp
@@ -46,7 +46,7 @@ namespace landmark {
 /*!
  * \brief DataType Landmark
  *
- * Landmark description in ENU coordiante frame.
+ * Landmark description in ECEF coordiante frame.
  */
 struct Landmark
 {

--- a/ad_map_access/generated/include/ad_map_access/Version.hpp
+++ b/ad_map_access/generated/include/ad_map_access/Version.hpp
@@ -25,7 +25,7 @@
 /*!
  * The minor version of ad_map_access
  */
-#define AD_MAP_ACCESS_VERSION_MINOR 1
+#define AD_MAP_ACCESS_VERSION_MINOR 2
 
 /*!
  * The revision of ad_map_access
@@ -35,4 +35,4 @@
 /*!
  * The version of ad_map_access as string
  */
-#define AD_MAP_ACCESS_VERSION_STRING "2.1.0"
+#define AD_MAP_ACCESS_VERSION_STRING "2.2.0"

--- a/ad_map_access/impl/include/ad/map/lane/LaneOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/lane/LaneOperation.hpp
@@ -94,6 +94,13 @@ point::ENUHeading getLaneENUHeading(point::ParaPoint const &paraPoint, point::Ge
 LaneId uniqueLaneId(point::GeoPoint const &point);
 
 /**
+* @return parametric point at given location
+*
+* Throws if there is more than one lane at the given position
+*/
+point::ParaPoint uniqueParaPoint(point::GeoPoint const &point);
+
+/**
  * @brief Checks if vehicle fits the lanes restriction criteria.
  * @param[in] lane the lane.
  * @param[in] vehicle Description of the vehicle.

--- a/ad_map_access/impl/include/ad/map/match/AdMapMatching.hpp
+++ b/ad_map_access/impl/include/ad/map/match/AdMapMatching.hpp
@@ -155,7 +155,7 @@ public:
    */
   MapMatchedPositionConfidenceList getMapMatchedPositions(point::GeoPoint const &geoPoint,
                                                           physics::Distance const &distance,
-                                                          physics::Probability const &minProbability);
+                                                          physics::Probability const &minProbability) const;
 
   /**
    * @brief get the map matched positions
@@ -170,7 +170,7 @@ public:
   MapMatchedPositionConfidenceList getMapMatchedPositions(point::ENUPoint const &enuPoint,
                                                           point::GeoPoint const &enuReferencePoint,
                                                           physics::Distance const &distance,
-                                                          physics::Probability const &minProbability);
+                                                          physics::Probability const &minProbability) const;
 
   /**
    * @brief get the map matched positions
@@ -186,7 +186,7 @@ public:
    */
   MapMatchedPositionConfidenceList getMapMatchedPositions(point::ENUPoint const &enuPoint,
                                                           physics::Distance const &distance,
-                                                          physics::Probability const &minProbability);
+                                                          physics::Probability const &minProbability) const;
 
   /**
    * @brief get the map matched positions
@@ -225,7 +225,7 @@ public:
    */
   MapMatchedObjectBoundingBox getMapMatchedBoundingBox(ENUObjectPosition const &enuObjectPosition,
                                                        physics::Distance const &samplingDistance
-                                                       = physics::Distance(1.));
+                                                       = physics::Distance(1.)) const;
 
   /**
    * @brief get the lane occupied regions from a list of ENUObjectPositionList
@@ -243,12 +243,13 @@ public:
    * @returns the map matched bounding box of the object
    */
   LaneOccupiedRegionList getLaneOccupiedRegions(ENUObjectPositionList enuObjectPositionList,
-                                                physics::Distance const &samplingDistance = physics::Distance(1.));
+                                                physics::Distance const &samplingDistance
+                                                = physics::Distance(1.)) const;
 
   /**
    * @brief Method to be called to retrieve the lane heading at a mapMatchedPosition
    */
-  point::ENUHeading getLaneENUHeading(MapMatchedPosition const &mapMatchedPosition);
+  point::ENUHeading getLaneENUHeading(MapMatchedPosition const &mapMatchedPosition) const;
 
   /**
    * @brief Spatial Lane Search.
@@ -303,14 +304,14 @@ private:
    */
 
   void addLaneRegions(LaneOccupiedRegionList &laneOccupiedRegions,
-                      MapMatchedPositionConfidenceList const &mapMatchedPositions);
+                      MapMatchedPositionConfidenceList const &mapMatchedPositions) const;
   void addLaneRegions(LaneOccupiedRegionList &laneOccupiedRegions,
-                      LaneOccupiedRegionList const &otherLaneOccupiedRegions);
+                      LaneOccupiedRegionList const &otherLaneOccupiedRegions) const;
 
   MapMatchedPositionConfidenceList considerMapMatchingHints(MapMatchedPositionConfidenceList const &mapMatchedPositions,
-                                                            physics::Probability const &minProbability);
-  bool isLanePartOfRouteHints(lane::LaneId const &laneId);
-  double getHeadingFactor(MapMatchedPosition const &matchedPosition);
+                                                            physics::Probability const &minProbability) const;
+  bool isLanePartOfRouteHints(lane::LaneId const &laneId) const;
+  double getHeadingFactor(MapMatchedPosition const &matchedPosition) const;
 
   std::list<point::ECEFHeading> mHeadingHints;
   double mHeadingHintFactor{2.};

--- a/ad_map_access/impl/include/ad/map/route/Planning.hpp
+++ b/ad_map_access/impl/include/ad/map/route/Planning.hpp
@@ -351,45 +351,80 @@ std::vector<route::FullRoute> predictRoutes(const match::MapMatchedObjectBoundin
                                             = RouteCreationMode::SameDrivingDirection);
 
 /**
+ * @brief Filter duplicated routes from a list of routes
+ *
+ * If one of the routes is a real sub-route of the other, the longer version of the route is kept, the shorter dropped
+ *
+ * @param[in] fullRoutes list of full routes to be filtered
+ *
+ * @returns the filtered list of routes
+ */
+std::vector<FullRoute> filterDuplicatedRoutes(const std::vector<FullRoute> fullRoutes);
+
+/**
  * @brief Calculate the connecting route between the the two objects
  *
  * For route calculations the route type core::Route::Type::SHORTEST_IGNORE_DIRECTION is used.
+ * The prediction hints are taken into account if no direct connecting route can be found in search of a merge route.
+ * If no prediction hints are given, respective route predictions are calculated internally.
  *
  * @param[in] startObject object at starting position
  * @param[in] destObject object at destination position
  * @param[in] maxDistance distance when the search can be stopped.
  * @param[in] maxDuration duration when the search can be stopped.
+ * @param[in] startObjectPredictionHints route prediction hints for start object (optional)
+ * @param[in] destObjectPredictionHints route prediction hints for dest object (optional)
  */
 ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
                                          const match::Object &destObject,
                                          physics::Distance const &maxDistance,
-                                         physics::Duration const &maxDuration);
+                                         physics::Duration const &maxDuration,
+                                         std::vector<route::FullRoute> const &startObjectPredictionHints
+                                         = std::vector<route::FullRoute>(),
+                                         std::vector<route::FullRoute> const &destObjectPredictionHints
+                                         = std::vector<route::FullRoute>());
 
 /**
  * @brief Calculate the connecting route between the the two objects
  *
  * For route calculations the route type core::Route::Type::SHORTEST_IGNORE_DIRECTION is used.
+ * The prediction hints are taken into account if no direct connecting route can be found in search of a merge route.
+ * If no prediction hints are given, respective route predictions are calculated internally.
  *
  * @param[in] startObject object at starting position
  * @param[in] destObject object at destination position
  * @param[in] maxDistance distance when the search can be stopped.
+ * @param[in] startObjectPredictionHints route prediction hints for start object (optional)
+ * @param[in] destObjectPredictionHints route prediction hints for dest object (optional)
  */
 ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
                                          const match::Object &destObject,
-                                         physics::Distance const &maxDistance);
+                                         physics::Distance const &maxDistance,
+                                         std::vector<route::FullRoute> const &startObjectPredictionHints
+                                         = std::vector<route::FullRoute>(),
+                                         std::vector<route::FullRoute> const &destObjectPredictionHints
+                                         = std::vector<route::FullRoute>());
 
 /**
  * @brief Calculate the connecting route between the the two objects
  *
  * For route calculations the route type core::Route::Type::SHORTEST_IGNORE_DIRECTION is used.
+ * The prediction hints are taken into account if no direct connecting route can be found in search of a merge route.
+ * If no prediction hints are given, respective route predictions are calculated internally.
  *
  * @param[in] startObject object at starting position
  * @param[in] destObject object at destination position
  * @param[in] maxDuration duration when the search can be stopped.
+ * @param[in] startObjectPredictionHints route prediction hints for start object (optional)
+ * @param[in] destObjectPredictionHints route prediction hints for dest object (optional)
  */
 ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
                                          const match::Object &destObject,
-                                         physics::Duration const &maxDuration);
+                                         physics::Duration const &maxDuration,
+                                         std::vector<route::FullRoute> const &startObjectPredictionHints
+                                         = std::vector<route::FullRoute>(),
+                                         std::vector<route::FullRoute> const &destObjectPredictionHints
+                                         = std::vector<route::FullRoute>());
 
 /**
  * @brief update route planning counters of the route

--- a/ad_map_access/impl/include/ad/map/route/RouteOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/route/RouteOperation.hpp
@@ -12,6 +12,7 @@
 #include "ad/map/match/Types.hpp"
 #include "ad/map/point/Types.hpp"
 #include "ad/map/route/LaneIntervalOperation.hpp"
+#include "ad/map/route/Routing.hpp"
 #include "ad/map/route/Types.hpp"
 #include "ad/physics/Types.hpp"
 
@@ -737,6 +738,40 @@ void appendLaneSegmentToRoute(route::LaneInterval const &laneInterval,
 bool extendRouteToDistance(route::FullRoute &route,
                            physics::Distance const &length,
                            std::vector<route::FullRoute> &additionalRoutes);
+
+/**
+ * @brief extends route with the given list of destinations
+ *
+ * @param[in/out] route the route to check and to extend
+ * @param[in] dest Vector with supporting points as routing parametric points to be visited on the route. Last point in
+ * the list is the
+ * actual destination point.
+ *
+ * @returns @c false is returned if the route is/was empty/degenerated
+ */
+bool extendRouteToDestinations(route::FullRoute &route, const std::vector<route::planning::RoutingParaPoint> &dest);
+
+/**
+ * @brief extends route with the given list of destinations
+ *
+ * @param[in/out] route the route to check and to extend
+ * @param[in] dest Vector with supporting points as geo points to be visited on the route. Last point in the list is the
+ * actual destination point.
+ *
+ * @returns @c false is returned if the route is/was empty/degenerated
+ */
+bool extendRouteToDestinations(route::FullRoute &route, const std::vector<point::GeoPoint> &dest);
+
+/**
+ * @brief extends route with the given list of destinations
+ *
+ * @param[in/out] route the route to check and to extend
+ * @param[in] dest Vector with supporting points as ENU points to be visited on the route. Last point in the list is the
+ * actual destination point.
+ *
+ * @returns @c false is returned if the route is/was empty/degenerated
+ */
+bool extendRouteToDestinations(route::FullRoute &route, const std::vector<point::ENUPoint> &dest);
 
 /** @brief function to append a new lane interval to a road segment list
  *

--- a/ad_map_access/impl/include/ad/map/serialize/ChecksumCRC32.hpp
+++ b/ad_map_access/impl/include/ad/map/serialize/ChecksumCRC32.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2019 Intel Corporation
+// Copyright (C) 2018-2020 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -19,6 +19,11 @@ namespace ad {
 namespace map {
 /** @brief namespace serialize */
 namespace serialize {
+
+/**
+ * @brief Standalone checksum CRC32 calculation
+ */
+uint32_t calculateCRC32Checksum(const void *x, size_t bytes);
 
 /**
  * @brief Checksum CRC32 calculation implementation

--- a/ad_map_access/impl/src/access/AdMapAccess.hpp
+++ b/ad_map_access/impl/src/access/AdMapAccess.hpp
@@ -57,8 +57,10 @@ public:
   /**
    * @brief initialize singleton with OpenDRIVE content string
    *
+   * If previously initialized with the same opendrive content the function performs nothing, but returns true.
+   *
    * The string contains the full OpenDRIVE data
-   * @return true if initialization was successful (i.e. config file exists or singleton was already initialized)
+   * @return true if initialization was successful.
    * @return false if OpenDRIVE data wasn't valid or the singleton was already initialized differently
    */
   bool initializeFromOpenDriveContent(std::string const &openDriveContent,
@@ -66,7 +68,6 @@ public:
                                       intersection::IntersectionType const defaultIntersectionType,
                                       landmark::TrafficLightType const defaultTrafficLightType
                                       = landmark::TrafficLightType::SOLID_RED_YELLOW_GREEN);
-
   /**
    * @brief initialize singleton with given store
    *
@@ -90,6 +91,8 @@ public:
   config::MapConfigFileHandler mConfigFileHandler{};
 
   bool mInitializedFromStore{false};
+
+  uint32_t mInitializeFromOpenDriveContentChecksum{0u};
 
   std::shared_ptr<spdlog::logger> mLogger;
 

--- a/ad_map_access/impl/src/lane/LaneOperation.cpp
+++ b/ad_map_access/impl/src/lane/LaneOperation.cpp
@@ -114,7 +114,7 @@ point::ENUHeading getLaneENUHeading(point::ParaPoint const &paraPoint, point::Ge
   return point::createENUHeading(getLaneECEFHeading(paraPoint), gnssReference);
 }
 
-LaneId uniqueLaneId(point::GeoPoint const &geoPoint)
+point::ParaPoint uniqueParaPoint(point::GeoPoint const &geoPoint)
 {
   match::AdMapMatching mapMatching;
   auto mapMatchingResult
@@ -125,7 +125,12 @@ LaneId uniqueLaneId(point::GeoPoint const &geoPoint)
     throw std::runtime_error("uniqueLaneId: position matches multiple lanes");
   }
 
-  return mapMatchingResult[0].lanePoint.paraPoint.laneId;
+  return mapMatchingResult[0].lanePoint.paraPoint;
+}
+
+LaneId uniqueLaneId(point::GeoPoint const &geoPoint)
+{
+  return uniqueParaPoint(geoPoint).laneId;
 }
 
 physics::Distance getWidth(Lane const &lane, physics::ParametricValue const &longitudinalOffset)

--- a/ad_map_access/impl/src/match/AdMapMatching.cpp
+++ b/ad_map_access/impl/src/match/AdMapMatching.cpp
@@ -126,12 +126,12 @@ AdMapMatching::AdMapMatching()
 {
 }
 
-point::ENUHeading AdMapMatching::getLaneENUHeading(MapMatchedPosition const &mapMatchedPosition)
+point::ENUHeading AdMapMatching::getLaneENUHeading(MapMatchedPosition const &mapMatchedPosition) const
 {
   return lane::getLaneENUHeading(mapMatchedPosition);
 }
 
-bool AdMapMatching::isLanePartOfRouteHints(lane::LaneId const &laneId)
+bool AdMapMatching::isLanePartOfRouteHints(lane::LaneId const &laneId) const
 {
   for (auto const &route : mRouteHints)
   {
@@ -149,7 +149,7 @@ bool AdMapMatching::isLanePartOfRouteHints(lane::LaneId const &laneId)
   return false;
 }
 
-double AdMapMatching::getHeadingFactor(MapMatchedPosition const &matchedPosition)
+double AdMapMatching::getHeadingFactor(MapMatchedPosition const &matchedPosition) const
 {
   double headingFactor = 1.0;
 
@@ -173,7 +173,7 @@ double AdMapMatching::getHeadingFactor(MapMatchedPosition const &matchedPosition
 
 MapMatchedPositionConfidenceList AdMapMatching::getMapMatchedPositions(point::GeoPoint const &geoPoint,
                                                                        physics::Distance const &distance,
-                                                                       physics::Probability const &minProbability)
+                                                                       physics::Probability const &minProbability) const
 {
   auto mapMatchingResult = findLanes(geoPoint, distance);
   mapMatchingResult = considerMapMatchingHints(mapMatchingResult, minProbability);
@@ -183,7 +183,7 @@ MapMatchedPositionConfidenceList AdMapMatching::getMapMatchedPositions(point::Ge
 
 MapMatchedPositionConfidenceList AdMapMatching::getMapMatchedPositions(point::ENUPoint const &enuPoint,
                                                                        physics::Distance const &distance,
-                                                                       physics::Probability const &minProbability)
+                                                                       physics::Probability const &minProbability) const
 {
   return getMapMatchedPositions(point::toGeo(enuPoint), distance, minProbability);
 }
@@ -191,7 +191,7 @@ MapMatchedPositionConfidenceList AdMapMatching::getMapMatchedPositions(point::EN
 MapMatchedPositionConfidenceList AdMapMatching::getMapMatchedPositions(point::ENUPoint const &enuPoint,
                                                                        point::GeoPoint const &enuReferencePoint,
                                                                        physics::Distance const &distance,
-                                                                       physics::Probability const &minProbability)
+                                                                       physics::Probability const &minProbability) const
 {
   return getMapMatchedPositions(point::toGeo(enuPoint, enuReferencePoint), distance, minProbability);
 }
@@ -209,7 +209,7 @@ MapMatchedPositionConfidenceList AdMapMatching::getMapMatchedPositions(ENUObject
 
 MapMatchedPositionConfidenceList
 AdMapMatching::considerMapMatchingHints(MapMatchedPositionConfidenceList const &mapMatchedPositions,
-                                        physics::Probability const &minProbability)
+                                        physics::Probability const &minProbability) const
 {
   access::getLogger()->trace("considerMapMatchingHints {}", mapMatchedPositions);
 
@@ -281,7 +281,7 @@ AdMapMatching::considerMapMatchingHints(MapMatchedPositionConfidenceList const &
 }
 
 MapMatchedObjectBoundingBox AdMapMatching::getMapMatchedBoundingBox(ENUObjectPosition const &enuObjectPosition,
-                                                                    physics::Distance const &samplingDistance)
+                                                                    physics::Distance const &samplingDistance) const
 {
   MapMatchedObjectBoundingBox mapMatchedObjectBoundingBox;
 
@@ -392,7 +392,7 @@ MapMatchedObjectBoundingBox AdMapMatching::getMapMatchedBoundingBox(ENUObjectPos
 }
 
 LaneOccupiedRegionList AdMapMatching::getLaneOccupiedRegions(std::vector<ENUObjectPosition> enuObjectPositions,
-                                                             physics::Distance const &samplingDistance)
+                                                             physics::Distance const &samplingDistance) const
 {
   LaneOccupiedRegionList laneOccupiedRegions;
 
@@ -434,7 +434,7 @@ inline bool isActualWithinLaneMatch(const MapMatchedPosition &mapMatchedPosition
 }
 
 void AdMapMatching::addLaneRegions(LaneOccupiedRegionList &laneOccupiedRegions,
-                                   MapMatchedPositionConfidenceList const &mapMatchedPositions)
+                                   MapMatchedPositionConfidenceList const &mapMatchedPositions) const
 {
   // Basic algorithm:
   // First, collect all actual matches within the respective lane (lateral AND longitudinal)
@@ -553,7 +553,7 @@ void AdMapMatching::addLaneRegions(LaneOccupiedRegionList &laneOccupiedRegions,
 }
 
 void AdMapMatching::addLaneRegions(LaneOccupiedRegionList &laneOccupiedRegions,
-                                   LaneOccupiedRegionList const &otherLaneOccupiedRegions)
+                                   LaneOccupiedRegionList const &otherLaneOccupiedRegions) const
 {
   for (auto const &otherRegion : otherLaneOccupiedRegions)
   {

--- a/ad_map_access/impl/src/route/Planning.cpp
+++ b/ad_map_access/impl/src/route/Planning.cpp
@@ -896,7 +896,9 @@ void dropOverlappingRegions(FullRoute &route,
 ConnectingRoute calculateConnectingRoute(const match::Object &objectA,
                                          const match::Object &objectB,
                                          physics::Distance const &maxDistance,
-                                         physics::Duration const &maxDuration)
+                                         physics::Duration const &maxDuration,
+                                         std::vector<route::FullRoute> const &objectAPredictionHints,
+                                         std::vector<route::FullRoute> const &objectBPredictionHints)
 {
   Route::RawRoute resultRawRoute;
   physics::Distance resultDistance = std::numeric_limits<physics::Distance>::max();
@@ -1005,8 +1007,16 @@ ConnectingRoute calculateConnectingRoute(const match::Object &objectA,
     // no direct connecting route between the two objects found
     // check if we have a ConnectingRouteType::Merging case
     // search if one of the route lanes of A is part of one of the route lanes of B
-    auto objectAPredictions = predictRoutes(objectA.mapMatchedBoundingBox, maxDistance, maxDuration);
-    auto objectBPredictions = predictRoutes(objectB.mapMatchedBoundingBox, maxDistance, maxDuration);
+    auto objectAPredictions = objectAPredictionHints;
+    if (objectAPredictions.empty())
+    {
+      objectAPredictions = predictRoutes(objectA.mapMatchedBoundingBox, maxDistance, maxDuration);
+    }
+    auto objectBPredictions = objectBPredictionHints;
+    if (objectBPredictions.empty())
+    {
+      objectBPredictions = predictRoutes(objectB.mapMatchedBoundingBox, maxDistance, maxDuration);
+    }
 
     resultDistance = std::numeric_limits<physics::Distance>::max();
     for (auto &objectAPrediction : objectAPredictions)
@@ -1031,16 +1041,30 @@ ConnectingRoute calculateConnectingRoute(const match::Object &objectA,
 
 ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
                                          const match::Object &destObject,
-                                         physics::Distance const &maxDistance)
+                                         physics::Distance const &maxDistance,
+                                         std::vector<route::FullRoute> const &objectAPredictionHints,
+                                         std::vector<route::FullRoute> const &objectBPredictionHints)
 {
-  return calculateConnectingRoute(startObject, destObject, maxDistance, std::numeric_limits<physics::Duration>::max());
+  return calculateConnectingRoute(startObject,
+                                  destObject,
+                                  maxDistance,
+                                  std::numeric_limits<physics::Duration>::max(),
+                                  objectAPredictionHints,
+                                  objectBPredictionHints);
 }
 
 ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
                                          const match::Object &destObject,
-                                         physics::Duration const &maxDuration)
+                                         physics::Duration const &maxDuration,
+                                         std::vector<route::FullRoute> const &objectAPredictionHints,
+                                         std::vector<route::FullRoute> const &objectBPredictionHints)
 {
-  return calculateConnectingRoute(startObject, destObject, std::numeric_limits<physics::Distance>::max(), maxDuration);
+  return calculateConnectingRoute(startObject,
+                                  destObject,
+                                  std::numeric_limits<physics::Distance>::max(),
+                                  maxDuration,
+                                  objectAPredictionHints,
+                                  objectBPredictionHints);
 }
 
 } // namespace planning

--- a/ad_map_access/impl/tests/access/AdMapAccessTests.cpp
+++ b/ad_map_access/impl/tests/access/AdMapAccessTests.cpp
@@ -73,6 +73,15 @@ TEST_F(AdMapAccessTest, initializeFromOpenDriveContent)
 
   ASSERT_TRUE(access::initFromOpenDriveContent(openDriveContent, 0.2, intersection::IntersectionType::TrafficLight));
 
+  // twice the same initialization works
+  ASSERT_TRUE(access::initFromOpenDriveContent(openDriveContent, 0.2, intersection::IntersectionType::TrafficLight));
+
+  std::ifstream mapFile3("test_files/Town03.xodr");
+  openDriveContentStream.clear();
+  openDriveContentStream << mapFile3.rdbuf();
+  openDriveContent = openDriveContentStream.str();
+
+  // but different content fails
   ASSERT_FALSE_NO_LOG(
     access::initFromOpenDriveContent(openDriveContent, 0.2, intersection::IntersectionType::TrafficLight));
 

--- a/ad_map_access/python/generate_python_lib.py.in
+++ b/ad_map_access/python/generate_python_lib.py.in
@@ -55,9 +55,10 @@ def main():
                             ignore_files=ignore_files)
 
     additional_replacements = {
-        # physics types used as default without full namespace in code
+        # types used as default without full namespace in code
         ("physics::Distance(", "ad::physics::Distance("),
         ("physics::ParametricValue(", "ad::physics::ParametricValue("),
+        ("std::vector<route::FullRoute>(", "std::vector<ad::map::route::FullRoute>("),
         ("nullptr", "0"),
         # some renaming for set data types
         ("\"vector_less__ad_scope_map_scope_lane_scope_LaneId__greater_\"", "\"LaneIdList\""),
@@ -65,7 +66,7 @@ def main():
         ("\"set_less__ad_scope_map_scope_landmark_scope_LandmarkId__greater_\"", "\"LandmarkIdSet\""),
         ("\"vector_less__ad_scope_map_scope_route_scope_ConnectingInterval__greater_\"", "\"ConnectingSegment\""),
         ("\"vector_less__ad_scope_map_scope_match_scope_MapMatchedPosition__greater_\"",
-         "\"MapMatchedPositionConfidenceList\""),
+         "\"MapMatchedPositionConfidenceList\"")
     }
 
     additional_replacements_python2=additional_replacements.copy()

--- a/ad_map_access_test_support/generated/CMakeLists.txt
+++ b/ad_map_access_test_support/generated/CMakeLists.txt
@@ -14,7 +14,7 @@
 ##
 
 cmake_minimum_required(VERSION 3.5)
-project(ad_map_access_test_support VERSION 2.1.0)
+project(ad_map_access_test_support VERSION 2.2.0)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -31,7 +31,7 @@ if ((NOT ad_map_access_test_support_SOURCES) OR (NOT ad_map_access_test_support_
   message(FATAL_ERROR "${PROJECT_NAME}: Variable ad_map_access_test_support_SOURCES or ad_map_access_test_support_INCLUDE_DIRS pointing to the generator managed library not set!")
 endif()
 
-find_package(ad_map_access 2.1.0 REQUIRED CONFIG)
+find_package(ad_map_access 2.2.0 REQUIRED CONFIG)
 
 add_library(${PROJECT_NAME}
   ${ad_map_access_test_support_SOURCES}

--- a/ad_map_access_test_support/generated/cmake/Config.cmake.in
+++ b/ad_map_access_test_support/generated/cmake/Config.cmake.in
@@ -17,7 +17,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(ad_map_access 2.1.0)
+find_dependency(ad_map_access 2.2.0)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 

--- a/ad_map_access_test_support/generated/include/ad_map_access_test_support/Version.hpp
+++ b/ad_map_access_test_support/generated/include/ad_map_access_test_support/Version.hpp
@@ -25,7 +25,7 @@
 /*!
  * The minor version of ad_map_access_test_support
  */
-#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_MINOR 1
+#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_MINOR 2
 
 /*!
  * The revision of ad_map_access_test_support
@@ -35,4 +35,4 @@
 /*!
  * The version of ad_map_access_test_support as string
  */
-#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_STRING "2.1.0"
+#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_STRING "2.2.0"

--- a/ad_physics/generated/CMakeLists.txt
+++ b/ad_physics/generated/CMakeLists.txt
@@ -14,7 +14,7 @@
 ##
 
 cmake_minimum_required(VERSION 3.5)
-project(ad_physics VERSION 2.1.0)
+project(ad_physics VERSION 2.2.0)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/ad_physics/generated/include/ad_physics/Version.hpp
+++ b/ad_physics/generated/include/ad_physics/Version.hpp
@@ -25,7 +25,7 @@
 /*!
  * The minor version of ad_physics
  */
-#define AD_PHYSICS_VERSION_MINOR 1
+#define AD_PHYSICS_VERSION_MINOR 2
 
 /*!
  * The revision of ad_physics
@@ -35,4 +35,4 @@
 /*!
  * The version of ad_physics as string
  */
-#define AD_PHYSICS_VERSION_STRING "2.1.0"
+#define AD_PHYSICS_VERSION_STRING "2.2.0"

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Latest changes
+
+## Release 2.2.0
+#### :ghost: Maintenance
 * Fix build of unit tests under Ubuntu18.04 with gcc 7.5.0
+* Added ad::map::route::extendRouteToDestinations()
+* Fixed AdMapMatching function constness
+* Made ad::map::route::filterDuplicateRoutes() public available
+* ad::map::access::initializeFromOpenDriveContent can be initialized twice with same open drive content
+* Build documentation update to make the plain cmake build more robust and especially make repeated builds with -DBUILD_PYTHON_BINDING=ON working
 
 ## Release 2.1.0
 #### :ghost: Maintenance


### PR DESCRIPTION
Added ad::map::route::extendRouteToDestinations()
Fixed AdMapMatching function constness
Made ad::map::route::filterDuplicateRoutes() public available
ad::map::access::initializeFromOpenDriveContent can be initialized twice with same open drive content
Build documentation update to make the plain cmake build more robust and especially make repeated builds with -DBUILD_PYTHON_BINDING=ON working

fixes #18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/map/20)
<!-- Reviewable:end -->
