### PR TITLE
Enhance support for building with C++ 17

### DIFF
--- a/ad_map_access/impl/include/ad/map/route/RoutePrediction.hpp
+++ b/ad_map_access/impl/include/ad/map/route/RoutePrediction.hpp
@@ -106,7 +106,7 @@ private:
     //! comparing route tree elements by their actual route-point to ensure children are unique
     struct RouteTreeElementCompare
     {
-      bool operator()(const std::shared_ptr<RouteTreeElement> &left, const std::shared_ptr<RouteTreeElement> &right)
+      bool operator()(const std::shared_ptr<RouteTreeElement> &left, const std::shared_ptr<RouteTreeElement> &right) const
       {
         return left->routingPoint.first < right->routingPoint.first;
       }

--- a/ad_map_access/impl/src/route/RouteAStar.cpp
+++ b/ad_map_access/impl/src/route/RouteAStar.cpp
@@ -106,7 +106,7 @@ bool RouteAstar::calculate()
     // sort the routing points by the smallest total cost
     struct FScoreCompare
     {
-      bool operator()(RoutingPoint const &left, RoutingPoint const &right)
+      bool operator()(RoutingPoint const &left, RoutingPoint const &right) const
       {
         return left.second.costData.estimatedDistanceToTarget < right.second.costData.estimatedDistanceToTarget;
       }


### PR DESCRIPTION
I would like to use RSS and this library in my project, when I build the source code under Ubuntu 18.04 by [bazel](https://bazel.build/) with C++17, GCC 7.5.0, I found this error:

```
In file included from /usr/include/c++/8/set:60,
                 from external/map_support/ad_map_access/impl/include/ad/map/route/Routing.hpp:11,
                 from external/map_support/ad_map_access/impl/include/ad/map/route/Route.hpp:15,
                 from external/map_support/ad_map_access/impl/include/ad/map/route/Planning.hpp:13,
                 from external/map_support/ad_map_access/impl/src/route/Planning.cpp:9:
/usr/include/c++/8/bits/stl_tree.h: In instantiation of 'class std::_Rb_tree<std::shared_ptr<ad::map::route::planning::RoutePrediction::RouteTreeElement>, std::shared_ptr<ad::map::route::planning::RoutePrediction::RouteTreeElement>, std::_Identity<std::shared_ptr<ad::map::route::planning::RoutePrediction::RouteTreeElement> >, ad::map::route::planning::RoutePrediction::RouteTreeElement::RouteTreeElementCompare, std::allocator<std::shared_ptr<ad::map::route::planning::RoutePrediction::RouteTreeElement> > >':
/usr/include/c++/8/bits/stl_set.h:133:17:   required from 'class std::set<std::shared_ptr<ad::map::route::planning::RoutePrediction::RouteTreeElement>, ad::map::route::planning::RoutePrediction::RouteTreeElement::RouteTreeElementCompare>'
external/map_support/ad_map_access/impl/include/ad/map/route/RoutePrediction.hpp:120:41:   required from here
/usr/include/c++/8/bits/stl_tree.h:457:21: error: static assertion failed: comparison object must be invocable as const
       static_assert(is_invocable_v<const _Compare&, const _Key&, const _Key&>,
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
 
The [fix](https://stackoverflow.com/questions/51235355/comparison-object-being-invocable-as-const) I found is simply add `const` after the struct method. After fixing this error, my project can be built successfully with C++17.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/map/21)
<!-- Reviewable:end -->
