### PR TITLE
Release 2.3.1

### DIFF
--- a/ad_map_access/generated/CMakeLists.txt
+++ b/ad_map_access/generated/CMakeLists.txt
@@ -14,7 +14,7 @@
 ##
 
 cmake_minimum_required(VERSION 3.5)
-project(ad_map_access VERSION 2.3.0)
+project(ad_map_access VERSION 2.3.1)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -47,7 +47,7 @@ get_target_property(AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS ad_map_opendr
 list(APPEND INCLUDE_DIRS ${AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS})
 list(APPEND LIBRARIES ad_map_opendrive_reader)
 
-find_package(ad_physics 2.3.0 REQUIRED CONFIG)
+find_package(ad_physics 2.3.1 REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 
 add_library(${PROJECT_NAME}

--- a/ad_map_access/generated/cmake/Config.cmake.in
+++ b/ad_map_access/generated/cmake/Config.cmake.in
@@ -30,7 +30,7 @@ get_target_property(AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS ad_map_opendr
 list(APPEND INCLUDE_DIRS ${AD_MAP_OPENDRIVE_READER_INTERFACE_INCLUDE_DIRS})
 list(APPEND LIBRARIES ad_map_opendrive_reader)
 
-find_dependency(ad_physics 2.3.0)
+find_dependency(ad_physics 2.3.1)
 find_dependency(spdlog)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/ad_map_access/generated/include/ad/map/lane/ECEFBorderList.hpp
+++ b/ad_map_access/generated/include/ad/map/lane/ECEFBorderList.hpp
@@ -1,0 +1,92 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include "ad/map/lane/ECEFBorder.hpp"
+/*!
+ * @brief namespace ad
+ */
+namespace ad {
+/*!
+ * @brief namespace map
+ */
+namespace map {
+/*!
+ * @brief namespace lane
+ *
+ * Handling of lanes
+ */
+namespace lane {
+
+/*!
+ * \brief DataType ECEFBorderList
+ *
+ * List of ECEFBorder elements
+ */
+typedef std::vector<::ad::map::lane::ECEFBorder> ECEFBorderList;
+
+} // namespace lane
+} // namespace map
+} // namespace ad
+
+/*!
+ * \brief protect the definition of functions from duplicates by typedef usage within other data types
+ */
+#ifndef GEN_GUARD_VECTOR_AD_MAP_LANE_ECEFBORDER
+#define GEN_GUARD_VECTOR_AD_MAP_LANE_ECEFBORDER
+namespace std {
+/**
+ * \brief standard ostream operator
+ *
+ * \param[in] os The output stream to write to
+ * \param[in] _value ECEFBorderList value
+ *
+ * \returns The stream object.
+ *
+ */
+inline std::ostream &operator<<(std::ostream &os, vector<::ad::map::lane::ECEFBorder> const &_value)
+{
+  os << "[";
+  for (auto it = _value.begin(); it != _value.end(); it++)
+  {
+    if (it != _value.begin())
+    {
+      os << ",";
+    }
+    os << *it;
+  }
+  os << "]";
+  return os;
+}
+} // namespace std
+
+namespace std {
+/*!
+ * \brief overload of the std::to_string for ECEFBorderList
+ */
+inline std::string to_string(::ad::map::lane::ECEFBorderList const &value)
+{
+  stringstream sstream;
+  sstream << value;
+  return sstream.str();
+}
+} // namespace std
+#endif // GEN_GUARD_VECTOR_AD_MAP_LANE_ECEFBORDER

--- a/ad_map_access/generated/include/ad/map/lane/ECEFBorderListValidInputRange.hpp
+++ b/ad_map_access/generated/include/ad/map/lane/ECEFBorderListValidInputRange.hpp
@@ -1,0 +1,58 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include "ad/map/lane/ECEFBorderList.hpp"
+#include "ad/map/lane/ECEFBorderValidInputRange.hpp"
+#include "spdlog/fmt/ostr.h"
+#include "spdlog/spdlog.h"
+
+/*!
+ * \brief check if the given ECEFBorderList is within valid input range
+ *
+ * \param[in] input the ECEFBorderList as an input value
+ * \param[in] logErrors enables error logging
+ *
+ * \returns \c true if ECEFBorderList is considered to be within the specified input range
+ *
+ * \note the specified input range is defined by
+ *       0 <= \c input.size() <= 0
+ *       and the ranges of all vector elements
+ */
+inline bool withinValidInputRange(::ad::map::lane::ECEFBorderList const &input, bool const logErrors = true)
+{
+  bool inValidInputRange = true;
+
+  if (inValidInputRange)
+  {
+    for (auto const &member : input)
+    {
+      bool memberInValidInputRange = withinValidInputRange(member, logErrors);
+      inValidInputRange = inValidInputRange && memberInValidInputRange;
+      if (!memberInValidInputRange && logErrors)
+      {
+        spdlog::error("withinValidInputRange(::ad::map::lane::ECEFBorderList)>> {}, invalid member {}",
+                      input,
+                      member); // LCOV_EXCL_BR_LINE
+      }
+    }
+  }
+  return inValidInputRange;
+}

--- a/ad_map_access/generated/include/ad/map/lane/ENUBorderList.hpp
+++ b/ad_map_access/generated/include/ad/map/lane/ENUBorderList.hpp
@@ -1,0 +1,92 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include "ad/map/lane/ENUBorder.hpp"
+/*!
+ * @brief namespace ad
+ */
+namespace ad {
+/*!
+ * @brief namespace map
+ */
+namespace map {
+/*!
+ * @brief namespace lane
+ *
+ * Handling of lanes
+ */
+namespace lane {
+
+/*!
+ * \brief DataType ENUBorderList
+ *
+ * List of ENUBorder elements
+ */
+typedef std::vector<::ad::map::lane::ENUBorder> ENUBorderList;
+
+} // namespace lane
+} // namespace map
+} // namespace ad
+
+/*!
+ * \brief protect the definition of functions from duplicates by typedef usage within other data types
+ */
+#ifndef GEN_GUARD_VECTOR_AD_MAP_LANE_ENUBORDER
+#define GEN_GUARD_VECTOR_AD_MAP_LANE_ENUBORDER
+namespace std {
+/**
+ * \brief standard ostream operator
+ *
+ * \param[in] os The output stream to write to
+ * \param[in] _value ENUBorderList value
+ *
+ * \returns The stream object.
+ *
+ */
+inline std::ostream &operator<<(std::ostream &os, vector<::ad::map::lane::ENUBorder> const &_value)
+{
+  os << "[";
+  for (auto it = _value.begin(); it != _value.end(); it++)
+  {
+    if (it != _value.begin())
+    {
+      os << ",";
+    }
+    os << *it;
+  }
+  os << "]";
+  return os;
+}
+} // namespace std
+
+namespace std {
+/*!
+ * \brief overload of the std::to_string for ENUBorderList
+ */
+inline std::string to_string(::ad::map::lane::ENUBorderList const &value)
+{
+  stringstream sstream;
+  sstream << value;
+  return sstream.str();
+}
+} // namespace std
+#endif // GEN_GUARD_VECTOR_AD_MAP_LANE_ENUBORDER

--- a/ad_map_access/generated/include/ad/map/lane/ENUBorderListValidInputRange.hpp
+++ b/ad_map_access/generated/include/ad/map/lane/ENUBorderListValidInputRange.hpp
@@ -1,0 +1,58 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include "ad/map/lane/ENUBorderList.hpp"
+#include "ad/map/lane/ENUBorderValidInputRange.hpp"
+#include "spdlog/fmt/ostr.h"
+#include "spdlog/spdlog.h"
+
+/*!
+ * \brief check if the given ENUBorderList is within valid input range
+ *
+ * \param[in] input the ENUBorderList as an input value
+ * \param[in] logErrors enables error logging
+ *
+ * \returns \c true if ENUBorderList is considered to be within the specified input range
+ *
+ * \note the specified input range is defined by
+ *       0 <= \c input.size() <= 0
+ *       and the ranges of all vector elements
+ */
+inline bool withinValidInputRange(::ad::map::lane::ENUBorderList const &input, bool const logErrors = true)
+{
+  bool inValidInputRange = true;
+
+  if (inValidInputRange)
+  {
+    for (auto const &member : input)
+    {
+      bool memberInValidInputRange = withinValidInputRange(member, logErrors);
+      inValidInputRange = inValidInputRange && memberInValidInputRange;
+      if (!memberInValidInputRange && logErrors)
+      {
+        spdlog::error("withinValidInputRange(::ad::map::lane::ENUBorderList)>> {}, invalid member {}",
+                      input,
+                      member); // LCOV_EXCL_BR_LINE
+      }
+    }
+  }
+  return inValidInputRange;
+}

--- a/ad_map_access/generated/include/ad/map/lane/GeoBorderList.hpp
+++ b/ad_map_access/generated/include/ad/map/lane/GeoBorderList.hpp
@@ -1,0 +1,92 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include "ad/map/lane/GeoBorder.hpp"
+/*!
+ * @brief namespace ad
+ */
+namespace ad {
+/*!
+ * @brief namespace map
+ */
+namespace map {
+/*!
+ * @brief namespace lane
+ *
+ * Handling of lanes
+ */
+namespace lane {
+
+/*!
+ * \brief DataType GeoBorderList
+ *
+ * List of GeoBorder elements
+ */
+typedef std::vector<::ad::map::lane::GeoBorder> GeoBorderList;
+
+} // namespace lane
+} // namespace map
+} // namespace ad
+
+/*!
+ * \brief protect the definition of functions from duplicates by typedef usage within other data types
+ */
+#ifndef GEN_GUARD_VECTOR_AD_MAP_LANE_GEOBORDER
+#define GEN_GUARD_VECTOR_AD_MAP_LANE_GEOBORDER
+namespace std {
+/**
+ * \brief standard ostream operator
+ *
+ * \param[in] os The output stream to write to
+ * \param[in] _value GeoBorderList value
+ *
+ * \returns The stream object.
+ *
+ */
+inline std::ostream &operator<<(std::ostream &os, vector<::ad::map::lane::GeoBorder> const &_value)
+{
+  os << "[";
+  for (auto it = _value.begin(); it != _value.end(); it++)
+  {
+    if (it != _value.begin())
+    {
+      os << ",";
+    }
+    os << *it;
+  }
+  os << "]";
+  return os;
+}
+} // namespace std
+
+namespace std {
+/*!
+ * \brief overload of the std::to_string for GeoBorderList
+ */
+inline std::string to_string(::ad::map::lane::GeoBorderList const &value)
+{
+  stringstream sstream;
+  sstream << value;
+  return sstream.str();
+}
+} // namespace std
+#endif // GEN_GUARD_VECTOR_AD_MAP_LANE_GEOBORDER

--- a/ad_map_access/generated/include/ad/map/lane/GeoBorderListValidInputRange.hpp
+++ b/ad_map_access/generated/include/ad/map/lane/GeoBorderListValidInputRange.hpp
@@ -1,0 +1,58 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include "ad/map/lane/GeoBorderList.hpp"
+#include "ad/map/lane/GeoBorderValidInputRange.hpp"
+#include "spdlog/fmt/ostr.h"
+#include "spdlog/spdlog.h"
+
+/*!
+ * \brief check if the given GeoBorderList is within valid input range
+ *
+ * \param[in] input the GeoBorderList as an input value
+ * \param[in] logErrors enables error logging
+ *
+ * \returns \c true if GeoBorderList is considered to be within the specified input range
+ *
+ * \note the specified input range is defined by
+ *       0 <= \c input.size() <= 0
+ *       and the ranges of all vector elements
+ */
+inline bool withinValidInputRange(::ad::map::lane::GeoBorderList const &input, bool const logErrors = true)
+{
+  bool inValidInputRange = true;
+
+  if (inValidInputRange)
+  {
+    for (auto const &member : input)
+    {
+      bool memberInValidInputRange = withinValidInputRange(member, logErrors);
+      inValidInputRange = inValidInputRange && memberInValidInputRange;
+      if (!memberInValidInputRange && logErrors)
+      {
+        spdlog::error("withinValidInputRange(::ad::map::lane::GeoBorderList)>> {}, invalid member {}",
+                      input,
+                      member); // LCOV_EXCL_BR_LINE
+      }
+    }
+  }
+  return inValidInputRange;
+}

--- a/ad_map_access/generated/include/ad/map/match/MapMatchedObjectBoundingBox.hpp
+++ b/ad_map_access/generated/include/ad/map/match/MapMatchedObjectBoundingBox.hpp
@@ -18,11 +18,12 @@
 #pragma once
 
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <sstream>
-#include <vector>
 #include "ad/map/match/LaneOccupiedRegionList.hpp"
-#include "ad/map/match/MapMatchedPositionConfidenceList.hpp"
+#include "ad/map/match/MapMatchedObjectReferencePositionList.hpp"
+#include "ad/physics/Distance.hpp"
 /*!
  * @brief namespace ad
  */
@@ -101,7 +102,8 @@ struct MapMatchedObjectBoundingBox
   bool operator==(const MapMatchedObjectBoundingBox &other) const
   {
     return (laneOccupiedRegions == other.laneOccupiedRegions)
-      && (referencePointPositions == other.referencePointPositions);
+      && (referencePointPositions == other.referencePointPositions) && (samplingDistance == other.samplingDistance)
+      && (matchRadius == other.matchRadius);
   }
 
   /**
@@ -117,8 +119,17 @@ struct MapMatchedObjectBoundingBox
   }
 
   ::ad::map::match::LaneOccupiedRegionList laneOccupiedRegions;
-  typedef std::vector<::ad::map::match::MapMatchedPositionConfidenceList> ReferencePointPositionsType;
-  ReferencePointPositionsType referencePointPositions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList referencePointPositions;
+
+  /*!
+   * Sampling distance used to calculate the bounding box.
+   */
+  ::ad::physics::Distance samplingDistance{0.0};
+
+  /*!
+   * The actual map matching radius around the object.
+   */
+  ::ad::physics::Distance matchRadius{0.0};
 };
 
 } // namespace match
@@ -161,19 +172,13 @@ inline std::ostream &operator<<(std::ostream &os, MapMatchedObjectBoundingBox co
   os << _value.laneOccupiedRegions;
   os << ",";
   os << "referencePointPositions:";
-  os << "[";
-  for (auto it_value_referencePointPositions = _value.referencePointPositions.begin();
-       it_value_referencePointPositions != _value.referencePointPositions.end();
-       it_value_referencePointPositions++)
-  {
-    if (it_value_referencePointPositions != _value.referencePointPositions.begin())
-    {
-      os << ",";
-    }
-    auto &_value_referencePointPositionsVal = *it_value_referencePointPositions;
-    os << _value_referencePointPositionsVal;
-  }
-  os << "]";
+  os << _value.referencePointPositions;
+  os << ",";
+  os << "samplingDistance:";
+  os << _value.samplingDistance;
+  os << ",";
+  os << "matchRadius:";
+  os << _value.matchRadius;
   os << ")";
   return os;
 }

--- a/ad_map_access/generated/include/ad/map/match/MapMatchedObjectBoundingBoxValidInputRange.hpp
+++ b/ad_map_access/generated/include/ad/map/match/MapMatchedObjectBoundingBoxValidInputRange.hpp
@@ -21,7 +21,10 @@
 #include <limits>
 #include "ad/map/match/LaneOccupiedRegionListValidInputRange.hpp"
 #include "ad/map/match/MapMatchedObjectBoundingBox.hpp"
-#include "ad/map/match/MapMatchedPositionConfidenceListValidInputRange.hpp"
+#include "ad/map/match/MapMatchedObjectReferencePositionListValidInputRange.hpp"
+#include "ad/physics/DistanceValidInputRange.hpp"
+#include "spdlog/fmt/ostr.h"
+#include "spdlog/spdlog.h"
 
 /*!
  * \brief check if the given MapMatchedObjectBoundingBox is within valid input range
@@ -37,8 +40,15 @@ inline bool withinValidInputRange(::ad::map::match::MapMatchedObjectBoundingBox 
                                   bool const logErrors = true)
 {
   // check for generic member input ranges
-  (void)input;
-  (void)logErrors;
   bool inValidInputRange = true;
+  inValidInputRange = withinValidInputRange(input.laneOccupiedRegions, logErrors)
+    && withinValidInputRange(input.referencePointPositions, logErrors)
+    && withinValidInputRange(input.samplingDistance, logErrors) && withinValidInputRange(input.matchRadius, logErrors);
+  if (!inValidInputRange && logErrors)
+  {
+    spdlog::error("withinValidInputRange(::ad::map::match::MapMatchedObjectBoundingBox)>> {} has invalid member",
+                  input); // LCOV_EXCL_BR_LINE
+  }
+
   return inValidInputRange;
 }

--- a/ad_map_access/generated/include/ad/map/match/MapMatchedObjectReferencePositionList.hpp
+++ b/ad_map_access/generated/include/ad/map/match/MapMatchedObjectReferencePositionList.hpp
@@ -1,0 +1,93 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include "ad/map/match/MapMatchedPositionConfidenceList.hpp"
+/*!
+ * @brief namespace ad
+ */
+namespace ad {
+/*!
+ * @brief namespace map
+ */
+namespace map {
+/*!
+ * @brief namespace match
+ *
+ * Map matching
+ */
+namespace match {
+
+/*!
+ * \brief DataType MapMatchedObjectReferencePositionList
+ *
+ * The list of the MapMatchedPositionConfidenceList of all ObjectReferencePoints.
+ */
+typedef std::vector<::ad::map::match::MapMatchedPositionConfidenceList> MapMatchedObjectReferencePositionList;
+
+} // namespace match
+} // namespace map
+} // namespace ad
+
+/*!
+ * \brief protect the definition of functions from duplicates by typedef usage within other data types
+ */
+#ifndef GEN_GUARD_VECTOR_VECTOR_AD_MAP_MATCH_MAPMATCHEDPOSITION
+#define GEN_GUARD_VECTOR_VECTOR_AD_MAP_MATCH_MAPMATCHEDPOSITION
+namespace std {
+/**
+ * \brief standard ostream operator
+ *
+ * \param[in] os The output stream to write to
+ * \param[in] _value MapMatchedObjectReferencePositionList value
+ *
+ * \returns The stream object.
+ *
+ */
+inline std::ostream &operator<<(std::ostream &os,
+                                vector<::ad::map::match::MapMatchedPositionConfidenceList> const &_value)
+{
+  os << "[";
+  for (auto it = _value.begin(); it != _value.end(); it++)
+  {
+    if (it != _value.begin())
+    {
+      os << ",";
+    }
+    os << *it;
+  }
+  os << "]";
+  return os;
+}
+} // namespace std
+
+namespace std {
+/*!
+ * \brief overload of the std::to_string for MapMatchedObjectReferencePositionList
+ */
+inline std::string to_string(::ad::map::match::MapMatchedObjectReferencePositionList const &value)
+{
+  stringstream sstream;
+  sstream << value;
+  return sstream.str();
+}
+} // namespace std
+#endif // GEN_GUARD_VECTOR_VECTOR_AD_MAP_MATCH_MAPMATCHEDPOSITION

--- a/ad_map_access/generated/include/ad/map/match/MapMatchedObjectReferencePositionListValidInputRange.hpp
+++ b/ad_map_access/generated/include/ad/map/match/MapMatchedObjectReferencePositionListValidInputRange.hpp
@@ -1,0 +1,62 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include "ad/map/match/MapMatchedObjectReferencePositionList.hpp"
+#include "ad/map/match/MapMatchedPositionConfidenceListValidInputRange.hpp"
+#include "spdlog/fmt/ostr.h"
+#include "spdlog/spdlog.h"
+
+/*!
+ * \brief check if the given MapMatchedObjectReferencePositionList is within valid input range
+ *
+ * \param[in] input the MapMatchedObjectReferencePositionList as an input value
+ * \param[in] logErrors enables error logging
+ *
+ * \returns \c true if MapMatchedObjectReferencePositionList is considered to be within the specified input range
+ *
+ * \note the specified input range is defined by
+ *       0 <= \c input.size() <= 0
+ *       and the ranges of all vector elements
+ */
+inline bool withinValidInputRange(::ad::map::match::MapMatchedObjectReferencePositionList const &input,
+                                  bool const logErrors = true)
+{
+  (void)input;
+  (void)logErrors;
+  bool inValidInputRange = true;
+
+  if (inValidInputRange)
+  {
+    for (auto const &member : input)
+    {
+      bool memberInValidInputRange = withinValidInputRange(member, logErrors);
+      inValidInputRange = inValidInputRange && memberInValidInputRange;
+      if (!memberInValidInputRange && logErrors)
+      {
+        spdlog::error(
+          "withinValidInputRange(::ad::map::match::MapMatchedObjectReferencePositionList)>> {}, invalid member {}",
+          input,
+          member); // LCOV_EXCL_BR_LINE
+      }
+    }
+  }
+  return inValidInputRange;
+}

--- a/ad_map_access/generated/include/ad/map/route/FullRouteList.hpp
+++ b/ad_map_access/generated/include/ad/map/route/FullRouteList.hpp
@@ -1,0 +1,92 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include "ad/map/route/FullRoute.hpp"
+/*!
+ * @brief namespace ad
+ */
+namespace ad {
+/*!
+ * @brief namespace map
+ */
+namespace map {
+/*!
+ * @brief namespace route
+ *
+ * Handling of routes
+ */
+namespace route {
+
+/*!
+ * \brief DataType FullRouteList
+ *
+ * List of FullRoute elements
+ */
+typedef std::vector<::ad::map::route::FullRoute> FullRouteList;
+
+} // namespace route
+} // namespace map
+} // namespace ad
+
+/*!
+ * \brief protect the definition of functions from duplicates by typedef usage within other data types
+ */
+#ifndef GEN_GUARD_VECTOR_AD_MAP_ROUTE_FULLROUTE
+#define GEN_GUARD_VECTOR_AD_MAP_ROUTE_FULLROUTE
+namespace std {
+/**
+ * \brief standard ostream operator
+ *
+ * \param[in] os The output stream to write to
+ * \param[in] _value FullRouteList value
+ *
+ * \returns The stream object.
+ *
+ */
+inline std::ostream &operator<<(std::ostream &os, vector<::ad::map::route::FullRoute> const &_value)
+{
+  os << "[";
+  for (auto it = _value.begin(); it != _value.end(); it++)
+  {
+    if (it != _value.begin())
+    {
+      os << ",";
+    }
+    os << *it;
+  }
+  os << "]";
+  return os;
+}
+} // namespace std
+
+namespace std {
+/*!
+ * \brief overload of the std::to_string for FullRouteList
+ */
+inline std::string to_string(::ad::map::route::FullRouteList const &value)
+{
+  stringstream sstream;
+  sstream << value;
+  return sstream.str();
+}
+} // namespace std
+#endif // GEN_GUARD_VECTOR_AD_MAP_ROUTE_FULLROUTE

--- a/ad_map_access/generated/include/ad/map/route/FullRouteListValidInputRange.hpp
+++ b/ad_map_access/generated/include/ad/map/route/FullRouteListValidInputRange.hpp
@@ -1,0 +1,58 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/**
+ * Generated file
+ * @file
+ *
+ * Generator Version : 11.0.0-1997
+ */
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include "ad/map/route/FullRouteList.hpp"
+#include "ad/map/route/FullRouteValidInputRange.hpp"
+#include "spdlog/fmt/ostr.h"
+#include "spdlog/spdlog.h"
+
+/*!
+ * \brief check if the given FullRouteList is within valid input range
+ *
+ * \param[in] input the FullRouteList as an input value
+ * \param[in] logErrors enables error logging
+ *
+ * \returns \c true if FullRouteList is considered to be within the specified input range
+ *
+ * \note the specified input range is defined by
+ *       0 <= \c input.size() <= 0
+ *       and the ranges of all vector elements
+ */
+inline bool withinValidInputRange(::ad::map::route::FullRouteList const &input, bool const logErrors = true)
+{
+  bool inValidInputRange = true;
+
+  if (inValidInputRange)
+  {
+    for (auto const &member : input)
+    {
+      bool memberInValidInputRange = withinValidInputRange(member, logErrors);
+      inValidInputRange = inValidInputRange && memberInValidInputRange;
+      if (!memberInValidInputRange && logErrors)
+      {
+        spdlog::error("withinValidInputRange(::ad::map::route::FullRouteList)>> {}, invalid member {}",
+                      input,
+                      member); // LCOV_EXCL_BR_LINE
+      }
+    }
+  }
+  return inValidInputRange;
+}

--- a/ad_map_access/generated/include/ad_map_access/Version.hpp
+++ b/ad_map_access/generated/include/ad_map_access/Version.hpp
@@ -30,9 +30,9 @@
 /*!
  * The revision of ad_map_access
  */
-#define AD_MAP_ACCESS_VERSION_REVISION 0
+#define AD_MAP_ACCESS_VERSION_REVISION 1
 
 /*!
  * The version of ad_map_access as string
  */
-#define AD_MAP_ACCESS_VERSION_STRING "2.3.0"
+#define AD_MAP_ACCESS_VERSION_STRING "2.3.1"

--- a/ad_map_access/impl/include/ad/map/lane/LaneOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/lane/LaneOperation.hpp
@@ -424,6 +424,21 @@ bool projectPositionToLaneInHeadingDirection(point::ParaPoint const &position,
 bool findNearestPointOnLane(Lane const &lane, point::ECEFPoint const &pt, match::MapMatchedPosition &mmpos);
 
 /**
+ * @brief Finds point on the lane interval nearest to the given point.
+ * @param[in] laneInterval the interval of the lane to be considered.
+ * @param[in] pt Given point.
+ * @param[out] mmpos Resulting map-matched position.
+ *   The resulting probability of the map matched position is derived from lateralT value:
+ *     spans between [0.5; 1.0] for LANE_IN matches
+ *     spans between [0.1; 0.5] for LANE_RIGHT/LANE_LEFT matches
+ *
+ * @returns true if successful.
+ */
+bool findNearestPointOnLaneInterval(route::LaneInterval const &laneInterval,
+                                    point::ECEFPoint const &pt,
+                                    match::MapMatchedPosition &mmpos);
+
+/**
  * @brief get the ENU point of a lane
  *
  */

--- a/ad_map_access/impl/include/ad/map/lane/Types.hpp
+++ b/ad_map_access/impl/include/ad/map/lane/Types.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2019 Intel Corporation
+// Copyright (C) 2018-2020 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -15,34 +15,14 @@
 #include "ad/map/lane/ContactLocationList.hpp"
 #include "ad/map/lane/ContactTypeList.hpp"
 #include "ad/map/lane/ECEFBorder.hpp"
+#include "ad/map/lane/ECEFBorderList.hpp"
 #include "ad/map/lane/ENUBorder.hpp"
+#include "ad/map/lane/ENUBorderList.hpp"
 #include "ad/map/lane/GeoBorder.hpp"
+#include "ad/map/lane/GeoBorderList.hpp"
 #include "ad/map/lane/Lane.hpp"
 #include "ad/map/lane/LaneDirection.hpp"
 #include "ad/map/lane/LaneId.hpp"
 #include "ad/map/lane/LaneIdList.hpp"
 #include "ad/map/lane/LaneIdSet.hpp"
 #include "ad/map/lane/LaneType.hpp"
-
-/*!
- * @brief namespace ad
- */
-namespace ad {
-/*!
- * @brief namespace map
- */
-namespace map {
-/*!
- * @brief namespace lane
- *
- * Handling of lanes
- */
-namespace lane {
-
-typedef std::vector<ad::map::lane::ENUBorder> ENUBorderList;
-typedef std::vector<ad::map::lane::ECEFBorder> ECEFBorderList;
-typedef std::vector<ad::map::lane::GeoBorder> GeoBorderList;
-
-} // namespace lane
-} // namespace map
-} // namespace ad

--- a/ad_map_access/impl/include/ad/map/match/AdMapMatching.hpp
+++ b/ad_map_access/impl/include/ad/map/match/AdMapMatching.hpp
@@ -278,6 +278,20 @@ public:
    */
   static MapMatchedPositionConfidenceList findLanes(point::GeoPoint const &geoPoint, physics::Distance const &distance);
 
+  /**
+   * @brief Spatial Lane Search.
+   *        Returns the map matched position in respect to all Lanes of the given route.
+   * @param[in] ecefPoint Point that is used as base for the search.
+   * @param[in] route The route providing the lane subset to be searched.
+   *
+   * This static function doesn't make use of any matching hints.
+   *
+   * @returns The individual matching result probabilities are relative to the actual distance of the matchedPoint to
+   * the queryPoint.
+   */
+  static MapMatchedPositionConfidenceList findRouteLanes(point::ECEFPoint const &ecefPoint,
+                                                         route::FullRoute const &route);
+
 private:
   // Copy operators and constructors are deleted to avoid accidental copies
   AdMapMatching(AdMapMatching const &) = delete;

--- a/ad_map_access/impl/include/ad/map/point/EdgeOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/point/EdgeOperation.hpp
@@ -204,12 +204,19 @@ std::vector<PointType> getParametricRange(std::vector<PointType> const &edge,
       const PointType &pt1 = edge[i + 1];
       physics::Distance d = distance(pt0, pt1);
       physics::Distance length_1 = length + d;
-      if ((d != physics::Distance(0)) && (length_1 >= length_t_start))
+      if (length_1 >= length_t_start)
       {
-        physics::Distance d_t = length_t_start - length;
-        physics::ParametricValue tt(d_t / d);
-        PointType pt_start = vectorInterpolate(pt0, pt1, tt);
-        pts.push_back(pt_start);
+        if (d != physics::Distance(0))
+        {
+          physics::Distance d_t = length_t_start - length;
+          physics::ParametricValue tt(d_t / d);
+          PointType pt_start = vectorInterpolate(pt0, pt1, tt);
+          pts.push_back(pt_start);
+        }
+        else
+        {
+          pts.push_back(pt1);
+        }
         break;
       }
       else
@@ -226,12 +233,19 @@ std::vector<PointType> getParametricRange(std::vector<PointType> const &edge,
         const PointType &pt1 = edge[i + 1];
         physics::Distance d = distance(pt0, pt1);
         physics::Distance length_1 = length + d;
-        if ((d != physics::Distance(0)) && (length_1 >= length_t_end))
+        if (length_1 >= length_t_end)
         {
-          physics::Distance d_t = length_t_end - length;
-          physics::ParametricValue tt(d_t / d);
-          PointType pt_end = vectorInterpolate(pt0, pt1, tt);
-          pts.push_back(pt_end);
+          if (d != physics::Distance(0))
+          {
+            physics::Distance d_t = length_t_end - length;
+            physics::ParametricValue tt(d_t / d);
+            PointType pt_end = vectorInterpolate(pt0, pt1, tt);
+            pts.push_back(pt_end);
+          }
+          else
+          {
+            pts.push_back(pt1);
+          }
           return pts;
         }
         else

--- a/ad_map_access/impl/include/ad/map/route/RouteOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/route/RouteOperation.hpp
@@ -737,7 +737,7 @@ void appendLaneSegmentToRoute(route::LaneInterval const &laneInterval,
  */
 bool extendRouteToDistance(route::FullRoute &route,
                            physics::Distance const &length,
-                           std::vector<route::FullRoute> &additionalRoutes);
+                           route::FullRouteList &additionalRoutes);
 
 /**
  * @brief extends route with the given list of destinations
@@ -928,7 +928,7 @@ inline lane::GeoBorder getGeoBorderOfRoadSegment(RoadSegment const &roadSegment)
  *
  * @param[in] route the route to extract the borders from
  */
-std::vector<lane::ENUBorder> getENUBorderOfRoute(FullRoute const &route);
+lane::ENUBorderList getENUBorderOfRoute(FullRoute const &route);
 
 /** @brief get borders of a full route
  *
@@ -937,7 +937,7 @@ std::vector<lane::ENUBorder> getENUBorderOfRoute(FullRoute const &route);
  *
  * @param[in] route the route to extract the borders from
  */
-std::vector<lane::ECEFBorder> getECEFBorderOfRoute(FullRoute const &route);
+lane::ECEFBorderList getECEFBorderOfRoute(FullRoute const &route);
 
 /** @brief get borders of a full route
  *
@@ -946,7 +946,7 @@ std::vector<lane::ECEFBorder> getECEFBorderOfRoute(FullRoute const &route);
  *
  * @param[in] route the route to extract the borders from
  */
-std::vector<lane::GeoBorder> getGeoBorderOfRoute(FullRoute const &route);
+lane::GeoBorderList getGeoBorderOfRoute(FullRoute const &route);
 
 /**
  * @brief get the ENU heading of a route at the location of the object

--- a/ad_map_access/impl/include/ad/map/route/Types.hpp
+++ b/ad_map_access/impl/include/ad/map/route/Types.hpp
@@ -11,26 +11,9 @@
 #include "ad/map/point/Types.hpp"
 #include "ad/map/route/ConnectingRoute.hpp"
 #include "ad/map/route/FullRoute.hpp"
+#include "ad/map/route/FullRouteList.hpp"
 #include "ad/map/route/LaneChangeDirection.hpp"
 #include "ad/map/route/LaneInterval.hpp"
 #include "ad/map/route/LaneSegment.hpp"
 #include "ad/map/route/RoadSegment.hpp"
 #include "ad/map/route/RouteParaPoint.hpp"
-
-namespace ad {
-/*!
- * @brief namespace map
- */
-namespace map {
-/*!
- * @brief namespace lane
- *
- * Handling of lanes
- */
-namespace route {
-
-typedef std::vector<ad::map::route::FullRoute> FullRouteList;
-
-} // namespace lane
-} // namespace map
-} // namespace ad

--- a/ad_map_access/impl/src/lane/BorderOperation.cpp
+++ b/ad_map_access/impl/src/lane/BorderOperation.cpp
@@ -18,7 +18,7 @@ namespace lane {
 
 physics::Distance calcLength(ENUBorderList const &borderList)
 {
-  physics::Distance total;
+  physics::Distance total(0.);
   for (auto const &value : borderList)
   {
     total = total + calcLength(value);
@@ -28,7 +28,7 @@ physics::Distance calcLength(ENUBorderList const &borderList)
 
 physics::Distance calcLength(ECEFBorderList const &borderList)
 {
-  physics::Distance total;
+  physics::Distance total(0.);
   for (auto const &value : borderList)
   {
     total = total + calcLength(value);
@@ -38,7 +38,7 @@ physics::Distance calcLength(ECEFBorderList const &borderList)
 
 physics::Distance calcLength(GeoBorderList const &borderList)
 {
-  physics::Distance total;
+  physics::Distance total(0.);
   for (auto const &value : borderList)
   {
     total = total + calcLength(value);
@@ -273,7 +273,9 @@ inline bool isPointWithinBorderPoints(point::ENUPoint const &ptLeft,
   auto const towardsLeft = ptLeft - enuPoint;
   auto const towardsRight = ptRight - enuPoint;
   auto const dotProduct = point::vectorDotProduct(towardsLeft, towardsRight);
-  return (dotProduct < 0.);
+  auto const withinBorders = (dotProduct < 0.) || (point::vectorLength(towardsLeft) < physics::Distance(0.01))
+    || (point::vectorLength(towardsRight) < physics::Distance(0.01));
+  return withinBorders;
 }
 
 inline point::ENUHeading createHeadingFromBorderPoints(point::ENUPoint const &ptLeft, point::ENUPoint const &ptRight)

--- a/ad_map_access/impl/src/route/RouteOperation.cpp
+++ b/ad_map_access/impl/src/route/RouteOperation.cpp
@@ -1177,7 +1177,7 @@ bool extendRouteToDestinations(route::FullRoute &route, const std::vector<point:
 
 bool extendRouteToDistance(route::FullRoute &route,
                            const physics::Distance &length,
-                           std::vector<route::FullRoute> &additionalRoutes)
+                           route::FullRouteList &additionalRoutes)
 {
   if (!additionalRoutes.empty())
   {
@@ -2246,9 +2246,9 @@ lane::GeoBorder getGeoBorderOfRoadSegment(RoadSegment const &roadSegment,
   return result;
 }
 
-std::vector<lane::ENUBorder> getENUBorderOfRoute(FullRoute const &route)
+lane::ENUBorderList getENUBorderOfRoute(FullRoute const &route)
 {
-  std::vector<lane::ENUBorder> enuBorderList;
+  lane::ENUBorderList enuBorderList;
   enuBorderList.reserve(route.roadSegments.size());
   for (auto const &roadSegment : route.roadSegments)
   {
@@ -2257,9 +2257,9 @@ std::vector<lane::ENUBorder> getENUBorderOfRoute(FullRoute const &route)
   return enuBorderList;
 }
 
-std::vector<lane::ECEFBorder> getECEFBorderOfRoute(FullRoute const &route)
+lane::ECEFBorderList getECEFBorderOfRoute(FullRoute const &route)
 {
-  std::vector<lane::ECEFBorder> ecefBorderList;
+  lane::ECEFBorderList ecefBorderList;
   ecefBorderList.reserve(route.roadSegments.size());
   for (auto const &roadSegment : route.roadSegments)
   {
@@ -2268,9 +2268,9 @@ std::vector<lane::ECEFBorder> getECEFBorderOfRoute(FullRoute const &route)
   return ecefBorderList;
 }
 
-std::vector<lane::GeoBorder> getGeoBorderOfRoute(FullRoute const &route)
+lane::GeoBorderList getGeoBorderOfRoute(FullRoute const &route)
 {
-  std::vector<lane::GeoBorder> geoBorderList;
+  lane::GeoBorderList geoBorderList;
   geoBorderList.reserve(route.roadSegments.size());
   for (auto const &roadSegment : route.roadSegments)
   {

--- a/ad_map_access/impl/tests/generated/ad/map/lane/ECEFBorderListTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/lane/ECEFBorderListTests.cpp
@@ -1,0 +1,34 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+
+#include <gtest/gtest.h>
+#include <limits>
+#include "ad/map/lane/ECEFBorderList.hpp"
+
+TEST(ECEFBorderListTests, ostreamOperatorTest)
+{
+  std::stringstream stream;
+  ::ad::map::lane::ECEFBorderList value;
+  stream << value;
+  ASSERT_GT(stream.str().size(), 0u);
+}
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic pop
+#endif

--- a/ad_map_access/impl/tests/generated/ad/map/lane/ECEFBorderListValidInputRangeTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/lane/ECEFBorderListValidInputRangeTests.cpp
@@ -1,0 +1,53 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "ad/map/lane/ECEFBorderListValidInputRange.hpp"
+
+TEST(ECEFBorderListValidInputRangeTests, testValidInputRangeValidInputRangeMin)
+{
+  ::ad::map::lane::ECEFBorderList value;
+  ASSERT_TRUE(withinValidInputRange(value));
+}
+
+TEST(ECEFBorderListValidInputRangeTests, testValidInputRangeElementValid)
+{
+  ::ad::map::lane::ECEFBorderList value;
+  ::ad::map::lane::ECEFBorder element;
+  ::ad::map::point::ECEFEdge elementLeft;
+  ::ad::map::point::ECEFPoint elementLeftElement;
+  ::ad::map::point::ECEFCoordinate elementLeftElementX(-6400000);
+  elementLeftElement.x = elementLeftElementX;
+  ::ad::map::point::ECEFCoordinate elementLeftElementY(-6400000);
+  elementLeftElement.y = elementLeftElementY;
+  ::ad::map::point::ECEFCoordinate elementLeftElementZ(-6400000);
+  elementLeftElement.z = elementLeftElementZ;
+  elementLeft.resize(1, elementLeftElement);
+  element.left = elementLeft;
+  ::ad::map::point::ECEFEdge elementRight;
+  ::ad::map::point::ECEFPoint elementRightElement;
+  ::ad::map::point::ECEFCoordinate elementRightElementX(-6400000);
+  elementRightElement.x = elementRightElementX;
+  ::ad::map::point::ECEFCoordinate elementRightElementY(-6400000);
+  elementRightElement.y = elementRightElementY;
+  ::ad::map::point::ECEFCoordinate elementRightElementZ(-6400000);
+  elementRightElement.z = elementRightElementZ;
+  elementRight.resize(1, elementRightElement);
+  element.right = elementRight;
+  value.push_back(element);
+  ASSERT_TRUE(withinValidInputRange(value));
+}

--- a/ad_map_access/impl/tests/generated/ad/map/lane/ENUBorderListTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/lane/ENUBorderListTests.cpp
@@ -1,0 +1,34 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+
+#include <gtest/gtest.h>
+#include <limits>
+#include "ad/map/lane/ENUBorderList.hpp"
+
+TEST(ENUBorderListTests, ostreamOperatorTest)
+{
+  std::stringstream stream;
+  ::ad::map::lane::ENUBorderList value;
+  stream << value;
+  ASSERT_GT(stream.str().size(), 0u);
+}
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic pop
+#endif

--- a/ad_map_access/impl/tests/generated/ad/map/lane/ENUBorderListValidInputRangeTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/lane/ENUBorderListValidInputRangeTests.cpp
@@ -1,0 +1,53 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "ad/map/lane/ENUBorderListValidInputRange.hpp"
+
+TEST(ENUBorderListValidInputRangeTests, testValidInputRangeValidInputRangeMin)
+{
+  ::ad::map::lane::ENUBorderList value;
+  ASSERT_TRUE(withinValidInputRange(value));
+}
+
+TEST(ENUBorderListValidInputRangeTests, testValidInputRangeElementValid)
+{
+  ::ad::map::lane::ENUBorderList value;
+  ::ad::map::lane::ENUBorder element;
+  ::ad::map::point::ENUEdge elementLeft;
+  ::ad::map::point::ENUPoint elementLeftElement;
+  ::ad::map::point::ENUCoordinate elementLeftElementX(-16384);
+  elementLeftElement.x = elementLeftElementX;
+  ::ad::map::point::ENUCoordinate elementLeftElementY(-16384);
+  elementLeftElement.y = elementLeftElementY;
+  ::ad::map::point::ENUCoordinate elementLeftElementZ(-16384);
+  elementLeftElement.z = elementLeftElementZ;
+  elementLeft.resize(1, elementLeftElement);
+  element.left = elementLeft;
+  ::ad::map::point::ENUEdge elementRight;
+  ::ad::map::point::ENUPoint elementRightElement;
+  ::ad::map::point::ENUCoordinate elementRightElementX(-16384);
+  elementRightElement.x = elementRightElementX;
+  ::ad::map::point::ENUCoordinate elementRightElementY(-16384);
+  elementRightElement.y = elementRightElementY;
+  ::ad::map::point::ENUCoordinate elementRightElementZ(-16384);
+  elementRightElement.z = elementRightElementZ;
+  elementRight.resize(1, elementRightElement);
+  element.right = elementRight;
+  value.push_back(element);
+  ASSERT_TRUE(withinValidInputRange(value));
+}

--- a/ad_map_access/impl/tests/generated/ad/map/lane/GeoBorderListTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/lane/GeoBorderListTests.cpp
@@ -1,0 +1,34 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+
+#include <gtest/gtest.h>
+#include <limits>
+#include "ad/map/lane/GeoBorderList.hpp"
+
+TEST(GeoBorderListTests, ostreamOperatorTest)
+{
+  std::stringstream stream;
+  ::ad::map::lane::GeoBorderList value;
+  stream << value;
+  ASSERT_GT(stream.str().size(), 0u);
+}
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic pop
+#endif

--- a/ad_map_access/impl/tests/generated/ad/map/lane/GeoBorderListValidInputRangeTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/lane/GeoBorderListValidInputRangeTests.cpp
@@ -1,0 +1,53 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "ad/map/lane/GeoBorderListValidInputRange.hpp"
+
+TEST(GeoBorderListValidInputRangeTests, testValidInputRangeValidInputRangeMin)
+{
+  ::ad::map::lane::GeoBorderList value;
+  ASSERT_TRUE(withinValidInputRange(value));
+}
+
+TEST(GeoBorderListValidInputRangeTests, testValidInputRangeElementValid)
+{
+  ::ad::map::lane::GeoBorderList value;
+  ::ad::map::lane::GeoBorder element;
+  ::ad::map::point::GeoEdge elementLeft;
+  ::ad::map::point::GeoPoint elementLeftElement;
+  ::ad::map::point::Longitude elementLeftElementLongitude(-180);
+  elementLeftElement.longitude = elementLeftElementLongitude;
+  ::ad::map::point::Latitude elementLeftElementLatitude(-90);
+  elementLeftElement.latitude = elementLeftElementLatitude;
+  ::ad::map::point::Altitude elementLeftElementAltitude(-11000);
+  elementLeftElement.altitude = elementLeftElementAltitude;
+  elementLeft.resize(1, elementLeftElement);
+  element.left = elementLeft;
+  ::ad::map::point::GeoEdge elementRight;
+  ::ad::map::point::GeoPoint elementRightElement;
+  ::ad::map::point::Longitude elementRightElementLongitude(-180);
+  elementRightElement.longitude = elementRightElementLongitude;
+  ::ad::map::point::Latitude elementRightElementLatitude(-90);
+  elementRightElement.latitude = elementRightElementLatitude;
+  ::ad::map::point::Altitude elementRightElementAltitude(-11000);
+  elementRightElement.altitude = elementRightElementAltitude;
+  elementRight.resize(1, elementRightElement);
+  element.right = elementRight;
+  value.push_back(element);
+  ASSERT_TRUE(withinValidInputRange(value));
+}

--- a/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectBoundingBoxTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectBoundingBoxTests.cpp
@@ -50,7 +50,7 @@ protected:
     valueLaneOccupiedRegionsElement.lateralRange = valueLaneOccupiedRegionsElementLateralRange;
     valueLaneOccupiedRegions.resize(1, valueLaneOccupiedRegionsElement);
     value.laneOccupiedRegions = valueLaneOccupiedRegions;
-    std::vector<::ad::map::match::MapMatchedPositionConfidenceList> valueReferencePointPositions;
+    ::ad::map::match::MapMatchedObjectReferencePositionList valueReferencePointPositions;
     ::ad::map::match::MapMatchedPositionConfidenceList valueReferencePointPositionsElement;
     ::ad::map::match::MapMatchedPosition valueReferencePointPositionsElementElement;
     ::ad::map::match::LanePoint valueReferencePointPositionsElementElementLanePoint;
@@ -99,8 +99,12 @@ protected:
     valueReferencePointPositionsElementElement.matchedPointDistance
       = valueReferencePointPositionsElementElementMatchedPointDistance;
     valueReferencePointPositionsElement.resize(1, valueReferencePointPositionsElementElement);
-    valueReferencePointPositions.push_back(valueReferencePointPositionsElement);
+    valueReferencePointPositions.resize(1, valueReferencePointPositionsElement);
     value.referencePointPositions = valueReferencePointPositions;
+    ::ad::physics::Distance valueSamplingDistance(-1e9);
+    value.samplingDistance = valueSamplingDistance;
+    ::ad::physics::Distance valueMatchRadius(-1e9);
+    value.matchRadius = valueMatchRadius;
     mValue = value;
   }
 
@@ -178,6 +182,85 @@ TEST_F(MapMatchedObjectBoundingBoxTests, comparisonOperatorLaneOccupiedRegionsDi
   laneOccupiedRegionsElement.lateralRange = laneOccupiedRegionsElementLateralRange;
   laneOccupiedRegions.resize(2, laneOccupiedRegionsElement);
   valueA.laneOccupiedRegions = laneOccupiedRegions;
+  ::ad::map::match::MapMatchedObjectBoundingBox valueB = mValue;
+
+  EXPECT_FALSE(valueA == valueB);
+  EXPECT_TRUE(valueA != valueB);
+}
+
+TEST_F(MapMatchedObjectBoundingBoxTests, comparisonOperatorReferencePointPositionsDiffers)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox valueA = mValue;
+  ::ad::map::match::MapMatchedObjectReferencePositionList referencePointPositions;
+  ::ad::map::match::MapMatchedPositionConfidenceList referencePointPositionsElement;
+  ::ad::map::match::MapMatchedPosition referencePointPositionsElementElement;
+  ::ad::map::match::LanePoint referencePointPositionsElementElementLanePoint;
+  ::ad::map::point::ParaPoint referencePointPositionsElementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId referencePointPositionsElementElementLanePointParaPointLaneId(
+    std::numeric_limits<::ad::map::lane::LaneId>::max());
+  referencePointPositionsElementElementLanePointParaPoint.laneId
+    = referencePointPositionsElementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue referencePointPositionsElementElementLanePointParaPointParametricOffset(1.);
+  referencePointPositionsElementElementLanePointParaPoint.parametricOffset
+    = referencePointPositionsElementElementLanePointParaPointParametricOffset;
+  referencePointPositionsElementElementLanePoint.paraPoint = referencePointPositionsElementElementLanePointParaPoint;
+  ::ad::physics::RatioValue referencePointPositionsElementElementLanePointLateralT(
+    std::numeric_limits<::ad::physics::RatioValue>::max());
+  referencePointPositionsElementElementLanePoint.lateralT = referencePointPositionsElementElementLanePointLateralT;
+  ::ad::physics::Distance referencePointPositionsElementElementLanePointLaneLength(1e9);
+  referencePointPositionsElementElementLanePoint.laneLength = referencePointPositionsElementElementLanePointLaneLength;
+  ::ad::physics::Distance referencePointPositionsElementElementLanePointLaneWidth(1e9);
+  referencePointPositionsElementElementLanePoint.laneWidth = referencePointPositionsElementElementLanePointLaneWidth;
+  referencePointPositionsElementElement.lanePoint = referencePointPositionsElementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType referencePointPositionsElementElementType(
+    ::ad::map::match::MapMatchedPositionType::LANE_RIGHT);
+  referencePointPositionsElementElement.type = referencePointPositionsElementElementType;
+  ::ad::map::point::ECEFPoint referencePointPositionsElementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate referencePointPositionsElementElementMatchedPointX(6400000);
+  referencePointPositionsElementElementMatchedPoint.x = referencePointPositionsElementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate referencePointPositionsElementElementMatchedPointY(6400000);
+  referencePointPositionsElementElementMatchedPoint.y = referencePointPositionsElementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate referencePointPositionsElementElementMatchedPointZ(6400000);
+  referencePointPositionsElementElementMatchedPoint.z = referencePointPositionsElementElementMatchedPointZ;
+  referencePointPositionsElementElement.matchedPoint = referencePointPositionsElementElementMatchedPoint;
+  ::ad::physics::Probability referencePointPositionsElementElementProbability(1.);
+  referencePointPositionsElementElement.probability = referencePointPositionsElementElementProbability;
+  ::ad::map::point::ECEFPoint referencePointPositionsElementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate referencePointPositionsElementElementQueryPointX(6400000);
+  referencePointPositionsElementElementQueryPoint.x = referencePointPositionsElementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate referencePointPositionsElementElementQueryPointY(6400000);
+  referencePointPositionsElementElementQueryPoint.y = referencePointPositionsElementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate referencePointPositionsElementElementQueryPointZ(6400000);
+  referencePointPositionsElementElementQueryPoint.z = referencePointPositionsElementElementQueryPointZ;
+  referencePointPositionsElementElement.queryPoint = referencePointPositionsElementElementQueryPoint;
+  ::ad::physics::Distance referencePointPositionsElementElementMatchedPointDistance(1e9);
+  referencePointPositionsElementElement.matchedPointDistance
+    = referencePointPositionsElementElementMatchedPointDistance;
+  referencePointPositionsElement.resize(2, referencePointPositionsElementElement);
+  referencePointPositions.resize(2, referencePointPositionsElement);
+  valueA.referencePointPositions = referencePointPositions;
+  ::ad::map::match::MapMatchedObjectBoundingBox valueB = mValue;
+
+  EXPECT_FALSE(valueA == valueB);
+  EXPECT_TRUE(valueA != valueB);
+}
+
+TEST_F(MapMatchedObjectBoundingBoxTests, comparisonOperatorSamplingDistanceDiffers)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox valueA = mValue;
+  ::ad::physics::Distance samplingDistance(1e9);
+  valueA.samplingDistance = samplingDistance;
+  ::ad::map::match::MapMatchedObjectBoundingBox valueB = mValue;
+
+  EXPECT_FALSE(valueA == valueB);
+  EXPECT_TRUE(valueA != valueB);
+}
+
+TEST_F(MapMatchedObjectBoundingBoxTests, comparisonOperatorMatchRadiusDiffers)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox valueA = mValue;
+  ::ad::physics::Distance matchRadius(1e9);
+  valueA.matchRadius = matchRadius;
   ::ad::map::match::MapMatchedObjectBoundingBox valueB = mValue;
 
   EXPECT_FALSE(valueA == valueB);

--- a/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectBoundingBoxValidInputRangeTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectBoundingBoxValidInputRangeTests.cpp
@@ -43,7 +43,7 @@ TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRange)
   valueLaneOccupiedRegionsElement.lateralRange = valueLaneOccupiedRegionsElementLateralRange;
   valueLaneOccupiedRegions.resize(1, valueLaneOccupiedRegionsElement);
   value.laneOccupiedRegions = valueLaneOccupiedRegions;
-  std::vector<::ad::map::match::MapMatchedPositionConfidenceList> valueReferencePointPositions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueReferencePointPositions;
   ::ad::map::match::MapMatchedPositionConfidenceList valueReferencePointPositionsElement;
   ::ad::map::match::MapMatchedPosition valueReferencePointPositionsElementElement;
   ::ad::map::match::LanePoint valueReferencePointPositionsElementElementLanePoint;
@@ -92,7 +92,375 @@ TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRange)
   valueReferencePointPositionsElementElement.matchedPointDistance
     = valueReferencePointPositionsElementElementMatchedPointDistance;
   valueReferencePointPositionsElement.resize(1, valueReferencePointPositionsElementElement);
-  valueReferencePointPositions.push_back(valueReferencePointPositionsElement);
+  valueReferencePointPositions.resize(1, valueReferencePointPositionsElement);
   value.referencePointPositions = valueReferencePointPositions;
+  ::ad::physics::Distance valueSamplingDistance(-1e9);
+  value.samplingDistance = valueSamplingDistance;
+  ::ad::physics::Distance valueMatchRadius(-1e9);
+  value.matchRadius = valueMatchRadius;
   ASSERT_TRUE(withinValidInputRange(value));
+}
+
+TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRangeSamplingDistanceTooSmall)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox value;
+  ::ad::map::match::LaneOccupiedRegionList valueLaneOccupiedRegions;
+  ::ad::map::match::LaneOccupiedRegion valueLaneOccupiedRegionsElement;
+  ::ad::map::lane::LaneId valueLaneOccupiedRegionsElementLaneId(1);
+  valueLaneOccupiedRegionsElement.laneId = valueLaneOccupiedRegionsElementLaneId;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRangeMaximum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRange.minimum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRange.maximum;
+  valueLaneOccupiedRegionsElement.longitudinalRange = valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLateralRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRangeMaximum;
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRange.minimum;
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRange.maximum;
+  valueLaneOccupiedRegionsElement.lateralRange = valueLaneOccupiedRegionsElementLateralRange;
+  valueLaneOccupiedRegions.resize(1, valueLaneOccupiedRegionsElement);
+  value.laneOccupiedRegions = valueLaneOccupiedRegions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueReferencePointPositions;
+  ::ad::map::match::MapMatchedPositionConfidenceList valueReferencePointPositionsElement;
+  ::ad::map::match::MapMatchedPosition valueReferencePointPositionsElementElement;
+  ::ad::map::match::LanePoint valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::point::ParaPoint valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId valueReferencePointPositionsElementElementLanePointParaPointLaneId(1);
+  valueReferencePointPositionsElementElementLanePointParaPoint.laneId
+    = valueReferencePointPositionsElementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue valueReferencePointPositionsElementElementLanePointParaPointParametricOffset(0.);
+  valueReferencePointPositionsElementElementLanePointParaPoint.parametricOffset
+    = valueReferencePointPositionsElementElementLanePointParaPointParametricOffset;
+  valueReferencePointPositionsElementElementLanePoint.paraPoint
+    = valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::physics::RatioValue valueReferencePointPositionsElementElementLanePointLateralT(
+    std::numeric_limits<::ad::physics::RatioValue>::lowest());
+  valueReferencePointPositionsElementElementLanePoint.lateralT
+    = valueReferencePointPositionsElementElementLanePointLateralT;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneLength(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneLength
+    = valueReferencePointPositionsElementElementLanePointLaneLength;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneWidth(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneWidth
+    = valueReferencePointPositionsElementElementLanePointLaneWidth;
+  valueReferencePointPositionsElementElement.lanePoint = valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType valueReferencePointPositionsElementElementType(
+    ::ad::map::match::MapMatchedPositionType::INVALID);
+  valueReferencePointPositionsElementElement.type = valueReferencePointPositionsElementElementType;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointX(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.x = valueReferencePointPositionsElementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointY(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.y = valueReferencePointPositionsElementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointZ(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.z = valueReferencePointPositionsElementElementMatchedPointZ;
+  valueReferencePointPositionsElementElement.matchedPoint = valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::physics::Probability valueReferencePointPositionsElementElementProbability(0.);
+  valueReferencePointPositionsElementElement.probability = valueReferencePointPositionsElementElementProbability;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointX(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.x = valueReferencePointPositionsElementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointY(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.y = valueReferencePointPositionsElementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointZ(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.z = valueReferencePointPositionsElementElementQueryPointZ;
+  valueReferencePointPositionsElementElement.queryPoint = valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementMatchedPointDistance(-1e9);
+  valueReferencePointPositionsElementElement.matchedPointDistance
+    = valueReferencePointPositionsElementElementMatchedPointDistance;
+  valueReferencePointPositionsElement.resize(1, valueReferencePointPositionsElementElement);
+  valueReferencePointPositions.resize(1, valueReferencePointPositionsElement);
+  value.referencePointPositions = valueReferencePointPositions;
+  ::ad::physics::Distance valueSamplingDistance(-1e9);
+  value.samplingDistance = valueSamplingDistance;
+  ::ad::physics::Distance valueMatchRadius(-1e9);
+  value.matchRadius = valueMatchRadius;
+
+  // override member with data type value below input range minimum
+  ::ad::physics::Distance invalidInitializedMember(-1e9 * 1.1);
+  value.samplingDistance = invalidInitializedMember;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
+TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRangeSamplingDistanceTooBig)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox value;
+  ::ad::map::match::LaneOccupiedRegionList valueLaneOccupiedRegions;
+  ::ad::map::match::LaneOccupiedRegion valueLaneOccupiedRegionsElement;
+  ::ad::map::lane::LaneId valueLaneOccupiedRegionsElementLaneId(1);
+  valueLaneOccupiedRegionsElement.laneId = valueLaneOccupiedRegionsElementLaneId;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRangeMaximum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRange.minimum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRange.maximum;
+  valueLaneOccupiedRegionsElement.longitudinalRange = valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLateralRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRangeMaximum;
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRange.minimum;
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRange.maximum;
+  valueLaneOccupiedRegionsElement.lateralRange = valueLaneOccupiedRegionsElementLateralRange;
+  valueLaneOccupiedRegions.resize(1, valueLaneOccupiedRegionsElement);
+  value.laneOccupiedRegions = valueLaneOccupiedRegions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueReferencePointPositions;
+  ::ad::map::match::MapMatchedPositionConfidenceList valueReferencePointPositionsElement;
+  ::ad::map::match::MapMatchedPosition valueReferencePointPositionsElementElement;
+  ::ad::map::match::LanePoint valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::point::ParaPoint valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId valueReferencePointPositionsElementElementLanePointParaPointLaneId(1);
+  valueReferencePointPositionsElementElementLanePointParaPoint.laneId
+    = valueReferencePointPositionsElementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue valueReferencePointPositionsElementElementLanePointParaPointParametricOffset(0.);
+  valueReferencePointPositionsElementElementLanePointParaPoint.parametricOffset
+    = valueReferencePointPositionsElementElementLanePointParaPointParametricOffset;
+  valueReferencePointPositionsElementElementLanePoint.paraPoint
+    = valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::physics::RatioValue valueReferencePointPositionsElementElementLanePointLateralT(
+    std::numeric_limits<::ad::physics::RatioValue>::lowest());
+  valueReferencePointPositionsElementElementLanePoint.lateralT
+    = valueReferencePointPositionsElementElementLanePointLateralT;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneLength(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneLength
+    = valueReferencePointPositionsElementElementLanePointLaneLength;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneWidth(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneWidth
+    = valueReferencePointPositionsElementElementLanePointLaneWidth;
+  valueReferencePointPositionsElementElement.lanePoint = valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType valueReferencePointPositionsElementElementType(
+    ::ad::map::match::MapMatchedPositionType::INVALID);
+  valueReferencePointPositionsElementElement.type = valueReferencePointPositionsElementElementType;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointX(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.x = valueReferencePointPositionsElementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointY(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.y = valueReferencePointPositionsElementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointZ(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.z = valueReferencePointPositionsElementElementMatchedPointZ;
+  valueReferencePointPositionsElementElement.matchedPoint = valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::physics::Probability valueReferencePointPositionsElementElementProbability(0.);
+  valueReferencePointPositionsElementElement.probability = valueReferencePointPositionsElementElementProbability;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointX(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.x = valueReferencePointPositionsElementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointY(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.y = valueReferencePointPositionsElementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointZ(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.z = valueReferencePointPositionsElementElementQueryPointZ;
+  valueReferencePointPositionsElementElement.queryPoint = valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementMatchedPointDistance(-1e9);
+  valueReferencePointPositionsElementElement.matchedPointDistance
+    = valueReferencePointPositionsElementElementMatchedPointDistance;
+  valueReferencePointPositionsElement.resize(1, valueReferencePointPositionsElementElement);
+  valueReferencePointPositions.resize(1, valueReferencePointPositionsElement);
+  value.referencePointPositions = valueReferencePointPositions;
+  ::ad::physics::Distance valueSamplingDistance(-1e9);
+  value.samplingDistance = valueSamplingDistance;
+  ::ad::physics::Distance valueMatchRadius(-1e9);
+  value.matchRadius = valueMatchRadius;
+
+  // override member with data type value above input range maximum
+  ::ad::physics::Distance invalidInitializedMember(1e9 * 1.1);
+  value.samplingDistance = invalidInitializedMember;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
+TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRangesamplingDistanceDefault)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox value;
+  ::ad::physics::Distance valueDefault;
+  value.samplingDistance = valueDefault;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
+TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRangeMatchRadiusTooSmall)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox value;
+  ::ad::map::match::LaneOccupiedRegionList valueLaneOccupiedRegions;
+  ::ad::map::match::LaneOccupiedRegion valueLaneOccupiedRegionsElement;
+  ::ad::map::lane::LaneId valueLaneOccupiedRegionsElementLaneId(1);
+  valueLaneOccupiedRegionsElement.laneId = valueLaneOccupiedRegionsElementLaneId;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRangeMaximum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRange.minimum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRange.maximum;
+  valueLaneOccupiedRegionsElement.longitudinalRange = valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLateralRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRangeMaximum;
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRange.minimum;
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRange.maximum;
+  valueLaneOccupiedRegionsElement.lateralRange = valueLaneOccupiedRegionsElementLateralRange;
+  valueLaneOccupiedRegions.resize(1, valueLaneOccupiedRegionsElement);
+  value.laneOccupiedRegions = valueLaneOccupiedRegions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueReferencePointPositions;
+  ::ad::map::match::MapMatchedPositionConfidenceList valueReferencePointPositionsElement;
+  ::ad::map::match::MapMatchedPosition valueReferencePointPositionsElementElement;
+  ::ad::map::match::LanePoint valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::point::ParaPoint valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId valueReferencePointPositionsElementElementLanePointParaPointLaneId(1);
+  valueReferencePointPositionsElementElementLanePointParaPoint.laneId
+    = valueReferencePointPositionsElementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue valueReferencePointPositionsElementElementLanePointParaPointParametricOffset(0.);
+  valueReferencePointPositionsElementElementLanePointParaPoint.parametricOffset
+    = valueReferencePointPositionsElementElementLanePointParaPointParametricOffset;
+  valueReferencePointPositionsElementElementLanePoint.paraPoint
+    = valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::physics::RatioValue valueReferencePointPositionsElementElementLanePointLateralT(
+    std::numeric_limits<::ad::physics::RatioValue>::lowest());
+  valueReferencePointPositionsElementElementLanePoint.lateralT
+    = valueReferencePointPositionsElementElementLanePointLateralT;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneLength(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneLength
+    = valueReferencePointPositionsElementElementLanePointLaneLength;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneWidth(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneWidth
+    = valueReferencePointPositionsElementElementLanePointLaneWidth;
+  valueReferencePointPositionsElementElement.lanePoint = valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType valueReferencePointPositionsElementElementType(
+    ::ad::map::match::MapMatchedPositionType::INVALID);
+  valueReferencePointPositionsElementElement.type = valueReferencePointPositionsElementElementType;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointX(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.x = valueReferencePointPositionsElementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointY(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.y = valueReferencePointPositionsElementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointZ(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.z = valueReferencePointPositionsElementElementMatchedPointZ;
+  valueReferencePointPositionsElementElement.matchedPoint = valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::physics::Probability valueReferencePointPositionsElementElementProbability(0.);
+  valueReferencePointPositionsElementElement.probability = valueReferencePointPositionsElementElementProbability;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointX(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.x = valueReferencePointPositionsElementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointY(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.y = valueReferencePointPositionsElementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointZ(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.z = valueReferencePointPositionsElementElementQueryPointZ;
+  valueReferencePointPositionsElementElement.queryPoint = valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementMatchedPointDistance(-1e9);
+  valueReferencePointPositionsElementElement.matchedPointDistance
+    = valueReferencePointPositionsElementElementMatchedPointDistance;
+  valueReferencePointPositionsElement.resize(1, valueReferencePointPositionsElementElement);
+  valueReferencePointPositions.resize(1, valueReferencePointPositionsElement);
+  value.referencePointPositions = valueReferencePointPositions;
+  ::ad::physics::Distance valueSamplingDistance(-1e9);
+  value.samplingDistance = valueSamplingDistance;
+  ::ad::physics::Distance valueMatchRadius(-1e9);
+  value.matchRadius = valueMatchRadius;
+
+  // override member with data type value below input range minimum
+  ::ad::physics::Distance invalidInitializedMember(-1e9 * 1.1);
+  value.matchRadius = invalidInitializedMember;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
+TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRangeMatchRadiusTooBig)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox value;
+  ::ad::map::match::LaneOccupiedRegionList valueLaneOccupiedRegions;
+  ::ad::map::match::LaneOccupiedRegion valueLaneOccupiedRegionsElement;
+  ::ad::map::lane::LaneId valueLaneOccupiedRegionsElementLaneId(1);
+  valueLaneOccupiedRegionsElement.laneId = valueLaneOccupiedRegionsElementLaneId;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLongitudinalRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRangeMaximum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.maximum = valueLaneOccupiedRegionsElementLongitudinalRange.minimum;
+  valueLaneOccupiedRegionsElementLongitudinalRange.minimum = valueLaneOccupiedRegionsElementLongitudinalRange.maximum;
+  valueLaneOccupiedRegionsElement.longitudinalRange = valueLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricRange valueLaneOccupiedRegionsElementLateralRange;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMinimum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRangeMinimum;
+  ::ad::physics::ParametricValue valueLaneOccupiedRegionsElementLateralRangeMaximum(0.);
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRangeMaximum;
+  valueLaneOccupiedRegionsElementLateralRange.maximum = valueLaneOccupiedRegionsElementLateralRange.minimum;
+  valueLaneOccupiedRegionsElementLateralRange.minimum = valueLaneOccupiedRegionsElementLateralRange.maximum;
+  valueLaneOccupiedRegionsElement.lateralRange = valueLaneOccupiedRegionsElementLateralRange;
+  valueLaneOccupiedRegions.resize(1, valueLaneOccupiedRegionsElement);
+  value.laneOccupiedRegions = valueLaneOccupiedRegions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueReferencePointPositions;
+  ::ad::map::match::MapMatchedPositionConfidenceList valueReferencePointPositionsElement;
+  ::ad::map::match::MapMatchedPosition valueReferencePointPositionsElementElement;
+  ::ad::map::match::LanePoint valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::point::ParaPoint valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId valueReferencePointPositionsElementElementLanePointParaPointLaneId(1);
+  valueReferencePointPositionsElementElementLanePointParaPoint.laneId
+    = valueReferencePointPositionsElementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue valueReferencePointPositionsElementElementLanePointParaPointParametricOffset(0.);
+  valueReferencePointPositionsElementElementLanePointParaPoint.parametricOffset
+    = valueReferencePointPositionsElementElementLanePointParaPointParametricOffset;
+  valueReferencePointPositionsElementElementLanePoint.paraPoint
+    = valueReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::physics::RatioValue valueReferencePointPositionsElementElementLanePointLateralT(
+    std::numeric_limits<::ad::physics::RatioValue>::lowest());
+  valueReferencePointPositionsElementElementLanePoint.lateralT
+    = valueReferencePointPositionsElementElementLanePointLateralT;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneLength(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneLength
+    = valueReferencePointPositionsElementElementLanePointLaneLength;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementLanePointLaneWidth(-1e9);
+  valueReferencePointPositionsElementElementLanePoint.laneWidth
+    = valueReferencePointPositionsElementElementLanePointLaneWidth;
+  valueReferencePointPositionsElementElement.lanePoint = valueReferencePointPositionsElementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType valueReferencePointPositionsElementElementType(
+    ::ad::map::match::MapMatchedPositionType::INVALID);
+  valueReferencePointPositionsElementElement.type = valueReferencePointPositionsElementElementType;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointX(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.x = valueReferencePointPositionsElementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointY(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.y = valueReferencePointPositionsElementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementMatchedPointZ(-6400000);
+  valueReferencePointPositionsElementElementMatchedPoint.z = valueReferencePointPositionsElementElementMatchedPointZ;
+  valueReferencePointPositionsElementElement.matchedPoint = valueReferencePointPositionsElementElementMatchedPoint;
+  ::ad::physics::Probability valueReferencePointPositionsElementElementProbability(0.);
+  valueReferencePointPositionsElementElement.probability = valueReferencePointPositionsElementElementProbability;
+  ::ad::map::point::ECEFPoint valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointX(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.x = valueReferencePointPositionsElementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointY(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.y = valueReferencePointPositionsElementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate valueReferencePointPositionsElementElementQueryPointZ(-6400000);
+  valueReferencePointPositionsElementElementQueryPoint.z = valueReferencePointPositionsElementElementQueryPointZ;
+  valueReferencePointPositionsElementElement.queryPoint = valueReferencePointPositionsElementElementQueryPoint;
+  ::ad::physics::Distance valueReferencePointPositionsElementElementMatchedPointDistance(-1e9);
+  valueReferencePointPositionsElementElement.matchedPointDistance
+    = valueReferencePointPositionsElementElementMatchedPointDistance;
+  valueReferencePointPositionsElement.resize(1, valueReferencePointPositionsElementElement);
+  valueReferencePointPositions.resize(1, valueReferencePointPositionsElement);
+  value.referencePointPositions = valueReferencePointPositions;
+  ::ad::physics::Distance valueSamplingDistance(-1e9);
+  value.samplingDistance = valueSamplingDistance;
+  ::ad::physics::Distance valueMatchRadius(-1e9);
+  value.matchRadius = valueMatchRadius;
+
+  // override member with data type value above input range maximum
+  ::ad::physics::Distance invalidInitializedMember(1e9 * 1.1);
+  value.matchRadius = invalidInitializedMember;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
+TEST(MapMatchedObjectBoundingBoxValidInputRangeTests, testValidInputRangematchRadiusDefault)
+{
+  ::ad::map::match::MapMatchedObjectBoundingBox value;
+  ::ad::physics::Distance valueDefault;
+  value.matchRadius = valueDefault;
+  ASSERT_FALSE(withinValidInputRange(value));
 }

--- a/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectReferencePositionListTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectReferencePositionListTests.cpp
@@ -1,0 +1,34 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+
+#include <gtest/gtest.h>
+#include <limits>
+#include "ad/map/match/MapMatchedObjectReferencePositionList.hpp"
+
+TEST(MapMatchedObjectReferencePositionListTests, ostreamOperatorTest)
+{
+  std::stringstream stream;
+  ::ad::map::match::MapMatchedObjectReferencePositionList value;
+  stream << value;
+  ASSERT_GT(stream.str().size(), 0u);
+}
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic pop
+#endif

--- a/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectReferencePositionListValidInputRangeTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/match/MapMatchedObjectReferencePositionListValidInputRangeTests.cpp
@@ -1,0 +1,71 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "ad/map/match/MapMatchedObjectReferencePositionListValidInputRange.hpp"
+
+TEST(MapMatchedObjectReferencePositionListValidInputRangeTests, testValidInputRangeValidInputRangeMin)
+{
+  ::ad::map::match::MapMatchedObjectReferencePositionList value;
+  ASSERT_TRUE(withinValidInputRange(value));
+}
+
+TEST(MapMatchedObjectReferencePositionListValidInputRangeTests, testValidInputRangeElementValid)
+{
+  ::ad::map::match::MapMatchedObjectReferencePositionList value;
+  ::ad::map::match::MapMatchedPositionConfidenceList element;
+  ::ad::map::match::MapMatchedPosition elementElement;
+  ::ad::map::match::LanePoint elementElementLanePoint;
+  ::ad::map::point::ParaPoint elementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId elementElementLanePointParaPointLaneId(1);
+  elementElementLanePointParaPoint.laneId = elementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue elementElementLanePointParaPointParametricOffset(0.);
+  elementElementLanePointParaPoint.parametricOffset = elementElementLanePointParaPointParametricOffset;
+  elementElementLanePoint.paraPoint = elementElementLanePointParaPoint;
+  ::ad::physics::RatioValue elementElementLanePointLateralT(std::numeric_limits<::ad::physics::RatioValue>::lowest());
+  elementElementLanePoint.lateralT = elementElementLanePointLateralT;
+  ::ad::physics::Distance elementElementLanePointLaneLength(-1e9);
+  elementElementLanePoint.laneLength = elementElementLanePointLaneLength;
+  ::ad::physics::Distance elementElementLanePointLaneWidth(-1e9);
+  elementElementLanePoint.laneWidth = elementElementLanePointLaneWidth;
+  elementElement.lanePoint = elementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType elementElementType(::ad::map::match::MapMatchedPositionType::INVALID);
+  elementElement.type = elementElementType;
+  ::ad::map::point::ECEFPoint elementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate elementElementMatchedPointX(-6400000);
+  elementElementMatchedPoint.x = elementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate elementElementMatchedPointY(-6400000);
+  elementElementMatchedPoint.y = elementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate elementElementMatchedPointZ(-6400000);
+  elementElementMatchedPoint.z = elementElementMatchedPointZ;
+  elementElement.matchedPoint = elementElementMatchedPoint;
+  ::ad::physics::Probability elementElementProbability(0.);
+  elementElement.probability = elementElementProbability;
+  ::ad::map::point::ECEFPoint elementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate elementElementQueryPointX(-6400000);
+  elementElementQueryPoint.x = elementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate elementElementQueryPointY(-6400000);
+  elementElementQueryPoint.y = elementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate elementElementQueryPointZ(-6400000);
+  elementElementQueryPoint.z = elementElementQueryPointZ;
+  elementElement.queryPoint = elementElementQueryPoint;
+  ::ad::physics::Distance elementElementMatchedPointDistance(-1e9);
+  elementElement.matchedPointDistance = elementElementMatchedPointDistance;
+  element.resize(1, elementElement);
+  value.push_back(element);
+  ASSERT_TRUE(withinValidInputRange(value));
+}

--- a/ad_map_access/impl/tests/generated/ad/map/match/ObjectTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/match/ObjectTests.cpp
@@ -90,7 +90,7 @@ protected:
       = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
     valueMapMatchedBoundingBoxLaneOccupiedRegions.resize(1, valueMapMatchedBoundingBoxLaneOccupiedRegionsElement);
     valueMapMatchedBoundingBox.laneOccupiedRegions = valueMapMatchedBoundingBoxLaneOccupiedRegions;
-    std::vector<::ad::map::match::MapMatchedPositionConfidenceList> valueMapMatchedBoundingBoxReferencePointPositions;
+    ::ad::map::match::MapMatchedObjectReferencePositionList valueMapMatchedBoundingBoxReferencePointPositions;
     ::ad::map::match::MapMatchedPositionConfidenceList valueMapMatchedBoundingBoxReferencePointPositionsElement;
     ::ad::map::match::MapMatchedPosition valueMapMatchedBoundingBoxReferencePointPositionsElementElement;
     ::ad::map::match::LanePoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
@@ -158,9 +158,13 @@ protected:
       = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance;
     valueMapMatchedBoundingBoxReferencePointPositionsElement.resize(
       1, valueMapMatchedBoundingBoxReferencePointPositionsElementElement);
-    valueMapMatchedBoundingBoxReferencePointPositions.push_back(
-      valueMapMatchedBoundingBoxReferencePointPositionsElement);
+    valueMapMatchedBoundingBoxReferencePointPositions.resize(1,
+                                                             valueMapMatchedBoundingBoxReferencePointPositionsElement);
     valueMapMatchedBoundingBox.referencePointPositions = valueMapMatchedBoundingBoxReferencePointPositions;
+    ::ad::physics::Distance valueMapMatchedBoundingBoxSamplingDistance(-1e9);
+    valueMapMatchedBoundingBox.samplingDistance = valueMapMatchedBoundingBoxSamplingDistance;
+    ::ad::physics::Distance valueMapMatchedBoundingBoxMatchRadius(-1e9);
+    valueMapMatchedBoundingBox.matchRadius = valueMapMatchedBoundingBoxMatchRadius;
     value.mapMatchedBoundingBox = valueMapMatchedBoundingBox;
     mValue = value;
   }
@@ -288,7 +292,7 @@ TEST_F(ObjectTests, comparisonOperatorMapMatchedBoundingBoxDiffers)
     = mapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
   mapMatchedBoundingBoxLaneOccupiedRegions.resize(2, mapMatchedBoundingBoxLaneOccupiedRegionsElement);
   mapMatchedBoundingBox.laneOccupiedRegions = mapMatchedBoundingBoxLaneOccupiedRegions;
-  std::vector<::ad::map::match::MapMatchedPositionConfidenceList> mapMatchedBoundingBoxReferencePointPositions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList mapMatchedBoundingBoxReferencePointPositions;
   ::ad::map::match::MapMatchedPositionConfidenceList mapMatchedBoundingBoxReferencePointPositionsElement;
   ::ad::map::match::MapMatchedPosition mapMatchedBoundingBoxReferencePointPositionsElementElement;
   ::ad::map::match::LanePoint mapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
@@ -351,8 +355,12 @@ TEST_F(ObjectTests, comparisonOperatorMapMatchedBoundingBoxDiffers)
     = mapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance;
   mapMatchedBoundingBoxReferencePointPositionsElement.resize(
     2, mapMatchedBoundingBoxReferencePointPositionsElementElement);
-  mapMatchedBoundingBoxReferencePointPositions.push_back(mapMatchedBoundingBoxReferencePointPositionsElement);
+  mapMatchedBoundingBoxReferencePointPositions.resize(2, mapMatchedBoundingBoxReferencePointPositionsElement);
   mapMatchedBoundingBox.referencePointPositions = mapMatchedBoundingBoxReferencePointPositions;
+  ::ad::physics::Distance mapMatchedBoundingBoxSamplingDistance(1e9);
+  mapMatchedBoundingBox.samplingDistance = mapMatchedBoundingBoxSamplingDistance;
+  ::ad::physics::Distance mapMatchedBoundingBoxMatchRadius(1e9);
+  mapMatchedBoundingBox.matchRadius = mapMatchedBoundingBoxMatchRadius;
   valueA.mapMatchedBoundingBox = mapMatchedBoundingBox;
   ::ad::map::match::Object valueB = mValue;
 

--- a/ad_map_access/impl/tests/generated/ad/map/match/ObjectValidInputRangeTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/match/ObjectValidInputRangeTests.cpp
@@ -83,7 +83,7 @@ TEST(ObjectValidInputRangeTests, testValidInputRange)
     = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
   valueMapMatchedBoundingBoxLaneOccupiedRegions.resize(1, valueMapMatchedBoundingBoxLaneOccupiedRegionsElement);
   valueMapMatchedBoundingBox.laneOccupiedRegions = valueMapMatchedBoundingBoxLaneOccupiedRegions;
-  std::vector<::ad::map::match::MapMatchedPositionConfidenceList> valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueMapMatchedBoundingBoxReferencePointPositions;
   ::ad::map::match::MapMatchedPositionConfidenceList valueMapMatchedBoundingBoxReferencePointPositionsElement;
   ::ad::map::match::MapMatchedPosition valueMapMatchedBoundingBoxReferencePointPositionsElementElement;
   ::ad::map::match::LanePoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
@@ -148,8 +148,12 @@ TEST(ObjectValidInputRangeTests, testValidInputRange)
     = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance;
   valueMapMatchedBoundingBoxReferencePointPositionsElement.resize(
     1, valueMapMatchedBoundingBoxReferencePointPositionsElementElement);
-  valueMapMatchedBoundingBoxReferencePointPositions.push_back(valueMapMatchedBoundingBoxReferencePointPositionsElement);
+  valueMapMatchedBoundingBoxReferencePointPositions.resize(1, valueMapMatchedBoundingBoxReferencePointPositionsElement);
   valueMapMatchedBoundingBox.referencePointPositions = valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxSamplingDistance(-1e9);
+  valueMapMatchedBoundingBox.samplingDistance = valueMapMatchedBoundingBoxSamplingDistance;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxMatchRadius(-1e9);
+  valueMapMatchedBoundingBox.matchRadius = valueMapMatchedBoundingBoxMatchRadius;
   value.mapMatchedBoundingBox = valueMapMatchedBoundingBox;
   ASSERT_TRUE(withinValidInputRange(value));
 }
@@ -219,7 +223,7 @@ TEST(ObjectValidInputRangeTests, testValidInputRangeEnuPositionTooSmall)
     = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
   valueMapMatchedBoundingBoxLaneOccupiedRegions.resize(1, valueMapMatchedBoundingBoxLaneOccupiedRegionsElement);
   valueMapMatchedBoundingBox.laneOccupiedRegions = valueMapMatchedBoundingBoxLaneOccupiedRegions;
-  std::vector<::ad::map::match::MapMatchedPositionConfidenceList> valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueMapMatchedBoundingBoxReferencePointPositions;
   ::ad::map::match::MapMatchedPositionConfidenceList valueMapMatchedBoundingBoxReferencePointPositionsElement;
   ::ad::map::match::MapMatchedPosition valueMapMatchedBoundingBoxReferencePointPositionsElementElement;
   ::ad::map::match::LanePoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
@@ -284,8 +288,12 @@ TEST(ObjectValidInputRangeTests, testValidInputRangeEnuPositionTooSmall)
     = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance;
   valueMapMatchedBoundingBoxReferencePointPositionsElement.resize(
     1, valueMapMatchedBoundingBoxReferencePointPositionsElementElement);
-  valueMapMatchedBoundingBoxReferencePointPositions.push_back(valueMapMatchedBoundingBoxReferencePointPositionsElement);
+  valueMapMatchedBoundingBoxReferencePointPositions.resize(1, valueMapMatchedBoundingBoxReferencePointPositionsElement);
   valueMapMatchedBoundingBox.referencePointPositions = valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxSamplingDistance(-1e9);
+  valueMapMatchedBoundingBox.samplingDistance = valueMapMatchedBoundingBoxSamplingDistance;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxMatchRadius(-1e9);
+  valueMapMatchedBoundingBox.matchRadius = valueMapMatchedBoundingBoxMatchRadius;
   value.mapMatchedBoundingBox = valueMapMatchedBoundingBox;
 
   // override member with data type value below input range minimum
@@ -363,7 +371,7 @@ TEST(ObjectValidInputRangeTests, testValidInputRangeEnuPositionTooBig)
     = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
   valueMapMatchedBoundingBoxLaneOccupiedRegions.resize(1, valueMapMatchedBoundingBoxLaneOccupiedRegionsElement);
   valueMapMatchedBoundingBox.laneOccupiedRegions = valueMapMatchedBoundingBoxLaneOccupiedRegions;
-  std::vector<::ad::map::match::MapMatchedPositionConfidenceList> valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueMapMatchedBoundingBoxReferencePointPositions;
   ::ad::map::match::MapMatchedPositionConfidenceList valueMapMatchedBoundingBoxReferencePointPositionsElement;
   ::ad::map::match::MapMatchedPosition valueMapMatchedBoundingBoxReferencePointPositionsElementElement;
   ::ad::map::match::LanePoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
@@ -428,8 +436,12 @@ TEST(ObjectValidInputRangeTests, testValidInputRangeEnuPositionTooBig)
     = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance;
   valueMapMatchedBoundingBoxReferencePointPositionsElement.resize(
     1, valueMapMatchedBoundingBoxReferencePointPositionsElementElement);
-  valueMapMatchedBoundingBoxReferencePointPositions.push_back(valueMapMatchedBoundingBoxReferencePointPositionsElement);
+  valueMapMatchedBoundingBoxReferencePointPositions.resize(1, valueMapMatchedBoundingBoxReferencePointPositionsElement);
   valueMapMatchedBoundingBox.referencePointPositions = valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxSamplingDistance(-1e9);
+  valueMapMatchedBoundingBox.samplingDistance = valueMapMatchedBoundingBoxSamplingDistance;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxMatchRadius(-1e9);
+  valueMapMatchedBoundingBox.matchRadius = valueMapMatchedBoundingBoxMatchRadius;
   value.mapMatchedBoundingBox = valueMapMatchedBoundingBox;
 
   // override member with data type value above input range maximum
@@ -439,5 +451,297 @@ TEST(ObjectValidInputRangeTests, testValidInputRangeEnuPositionTooBig)
   invalidInitializedMemberCenterPoint.x = invalidInitializedMemberCenterPointX;
   invalidInitializedMember.centerPoint = invalidInitializedMemberCenterPoint;
   value.enuPosition = invalidInitializedMember;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
+TEST(ObjectValidInputRangeTests, testValidInputRangeMapMatchedBoundingBoxTooSmall)
+{
+  ::ad::map::match::Object value;
+  ::ad::map::match::ENUObjectPosition valueEnuPosition;
+  ::ad::map::point::ENUPoint valueEnuPositionCenterPoint;
+  ::ad::map::point::ENUCoordinate valueEnuPositionCenterPointX(-16384);
+  valueEnuPositionCenterPoint.x = valueEnuPositionCenterPointX;
+  ::ad::map::point::ENUCoordinate valueEnuPositionCenterPointY(-16384);
+  valueEnuPositionCenterPoint.y = valueEnuPositionCenterPointY;
+  ::ad::map::point::ENUCoordinate valueEnuPositionCenterPointZ(-16384);
+  valueEnuPositionCenterPoint.z = valueEnuPositionCenterPointZ;
+  valueEnuPosition.centerPoint = valueEnuPositionCenterPoint;
+  ::ad::map::point::ENUHeading valueEnuPositionHeading(-3.141592655);
+  valueEnuPosition.heading = valueEnuPositionHeading;
+  ::ad::map::point::GeoPoint valueEnuPositionEnuReferencePoint;
+  ::ad::map::point::Longitude valueEnuPositionEnuReferencePointLongitude(-180);
+  valueEnuPositionEnuReferencePoint.longitude = valueEnuPositionEnuReferencePointLongitude;
+  ::ad::map::point::Latitude valueEnuPositionEnuReferencePointLatitude(-90);
+  valueEnuPositionEnuReferencePoint.latitude = valueEnuPositionEnuReferencePointLatitude;
+  ::ad::map::point::Altitude valueEnuPositionEnuReferencePointAltitude(-11000);
+  valueEnuPositionEnuReferencePoint.altitude = valueEnuPositionEnuReferencePointAltitude;
+  valueEnuPosition.enuReferencePoint = valueEnuPositionEnuReferencePoint;
+  ::ad::physics::Dimension3D valueEnuPositionDimension;
+  ::ad::physics::Distance valueEnuPositionDimensionLength(-1e9);
+  valueEnuPositionDimension.length = valueEnuPositionDimensionLength;
+  ::ad::physics::Distance valueEnuPositionDimensionWidth(-1e9);
+  valueEnuPositionDimension.width = valueEnuPositionDimensionWidth;
+  ::ad::physics::Distance valueEnuPositionDimensionHeight(-1e9);
+  valueEnuPositionDimension.height = valueEnuPositionDimensionHeight;
+  valueEnuPosition.dimension = valueEnuPositionDimension;
+  value.enuPosition = valueEnuPosition;
+  ::ad::map::match::MapMatchedObjectBoundingBox valueMapMatchedBoundingBox;
+  ::ad::map::match::LaneOccupiedRegionList valueMapMatchedBoundingBoxLaneOccupiedRegions;
+  ::ad::map::match::LaneOccupiedRegion valueMapMatchedBoundingBoxLaneOccupiedRegionsElement;
+  ::ad::map::lane::LaneId valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLaneId(1);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElement.laneId
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLaneId;
+  ::ad::physics::ParametricRange valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMinimum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMinimum;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMaximum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMaximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.minimum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.maximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElement.longitudinalRange
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricRange valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMinimum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMinimum;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMaximum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMaximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.minimum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.maximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElement.lateralRange
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
+  valueMapMatchedBoundingBoxLaneOccupiedRegions.resize(1, valueMapMatchedBoundingBoxLaneOccupiedRegionsElement);
+  valueMapMatchedBoundingBox.laneOccupiedRegions = valueMapMatchedBoundingBoxLaneOccupiedRegions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::map::match::MapMatchedPositionConfidenceList valueMapMatchedBoundingBoxReferencePointPositionsElement;
+  ::ad::map::match::MapMatchedPosition valueMapMatchedBoundingBoxReferencePointPositionsElementElement;
+  ::ad::map::match::LanePoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
+  ::ad::map::point::ParaPoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointLaneId(1);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint.laneId
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue
+    valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointParametricOffset(0.);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint.parametricOffset
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointParametricOffset;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.paraPoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::physics::RatioValue valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLateralT(
+    std::numeric_limits<::ad::physics::RatioValue>::lowest());
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.lateralT
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLateralT;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneLength(-1e9);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.laneLength
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneLength;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneWidth(-1e9);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.laneWidth
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneWidth;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.lanePoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType valueMapMatchedBoundingBoxReferencePointPositionsElementElementType(
+    ::ad::map::match::MapMatchedPositionType::INVALID);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.type
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementType;
+  ::ad::map::point::ECEFPoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointX(
+    -6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint.x
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointY(
+    -6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint.y
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointZ(
+    -6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint.z
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointZ;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.matchedPoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint;
+  ::ad::physics::Probability valueMapMatchedBoundingBoxReferencePointPositionsElementElementProbability(0.);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.probability
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementProbability;
+  ::ad::map::point::ECEFPoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointX(-6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint.x
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointY(-6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint.y
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointZ(-6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint.z
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointZ;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.queryPoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance(-1e9);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.matchedPointDistance
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance;
+  valueMapMatchedBoundingBoxReferencePointPositionsElement.resize(
+    1, valueMapMatchedBoundingBoxReferencePointPositionsElementElement);
+  valueMapMatchedBoundingBoxReferencePointPositions.resize(1, valueMapMatchedBoundingBoxReferencePointPositionsElement);
+  valueMapMatchedBoundingBox.referencePointPositions = valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxSamplingDistance(-1e9);
+  valueMapMatchedBoundingBox.samplingDistance = valueMapMatchedBoundingBoxSamplingDistance;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxMatchRadius(-1e9);
+  valueMapMatchedBoundingBox.matchRadius = valueMapMatchedBoundingBoxMatchRadius;
+  value.mapMatchedBoundingBox = valueMapMatchedBoundingBox;
+
+  // override member with data type value below input range minimum
+  ::ad::map::match::MapMatchedObjectBoundingBox invalidInitializedMember;
+  ::ad::physics::Distance invalidInitializedMemberSamplingDistance(-1e9 * 1.1);
+  invalidInitializedMember.samplingDistance = invalidInitializedMemberSamplingDistance;
+  value.mapMatchedBoundingBox = invalidInitializedMember;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
+TEST(ObjectValidInputRangeTests, testValidInputRangeMapMatchedBoundingBoxTooBig)
+{
+  ::ad::map::match::Object value;
+  ::ad::map::match::ENUObjectPosition valueEnuPosition;
+  ::ad::map::point::ENUPoint valueEnuPositionCenterPoint;
+  ::ad::map::point::ENUCoordinate valueEnuPositionCenterPointX(-16384);
+  valueEnuPositionCenterPoint.x = valueEnuPositionCenterPointX;
+  ::ad::map::point::ENUCoordinate valueEnuPositionCenterPointY(-16384);
+  valueEnuPositionCenterPoint.y = valueEnuPositionCenterPointY;
+  ::ad::map::point::ENUCoordinate valueEnuPositionCenterPointZ(-16384);
+  valueEnuPositionCenterPoint.z = valueEnuPositionCenterPointZ;
+  valueEnuPosition.centerPoint = valueEnuPositionCenterPoint;
+  ::ad::map::point::ENUHeading valueEnuPositionHeading(-3.141592655);
+  valueEnuPosition.heading = valueEnuPositionHeading;
+  ::ad::map::point::GeoPoint valueEnuPositionEnuReferencePoint;
+  ::ad::map::point::Longitude valueEnuPositionEnuReferencePointLongitude(-180);
+  valueEnuPositionEnuReferencePoint.longitude = valueEnuPositionEnuReferencePointLongitude;
+  ::ad::map::point::Latitude valueEnuPositionEnuReferencePointLatitude(-90);
+  valueEnuPositionEnuReferencePoint.latitude = valueEnuPositionEnuReferencePointLatitude;
+  ::ad::map::point::Altitude valueEnuPositionEnuReferencePointAltitude(-11000);
+  valueEnuPositionEnuReferencePoint.altitude = valueEnuPositionEnuReferencePointAltitude;
+  valueEnuPosition.enuReferencePoint = valueEnuPositionEnuReferencePoint;
+  ::ad::physics::Dimension3D valueEnuPositionDimension;
+  ::ad::physics::Distance valueEnuPositionDimensionLength(-1e9);
+  valueEnuPositionDimension.length = valueEnuPositionDimensionLength;
+  ::ad::physics::Distance valueEnuPositionDimensionWidth(-1e9);
+  valueEnuPositionDimension.width = valueEnuPositionDimensionWidth;
+  ::ad::physics::Distance valueEnuPositionDimensionHeight(-1e9);
+  valueEnuPositionDimension.height = valueEnuPositionDimensionHeight;
+  valueEnuPosition.dimension = valueEnuPositionDimension;
+  value.enuPosition = valueEnuPosition;
+  ::ad::map::match::MapMatchedObjectBoundingBox valueMapMatchedBoundingBox;
+  ::ad::map::match::LaneOccupiedRegionList valueMapMatchedBoundingBoxLaneOccupiedRegions;
+  ::ad::map::match::LaneOccupiedRegion valueMapMatchedBoundingBoxLaneOccupiedRegionsElement;
+  ::ad::map::lane::LaneId valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLaneId(1);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElement.laneId
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLaneId;
+  ::ad::physics::ParametricRange valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMinimum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMinimum;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMaximum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRangeMaximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.minimum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange.maximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElement.longitudinalRange
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLongitudinalRange;
+  ::ad::physics::ParametricRange valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMinimum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMinimum;
+  ::ad::physics::ParametricValue valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMaximum(0.);
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRangeMaximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.maximum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.minimum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.minimum
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange.maximum;
+  valueMapMatchedBoundingBoxLaneOccupiedRegionsElement.lateralRange
+    = valueMapMatchedBoundingBoxLaneOccupiedRegionsElementLateralRange;
+  valueMapMatchedBoundingBoxLaneOccupiedRegions.resize(1, valueMapMatchedBoundingBoxLaneOccupiedRegionsElement);
+  valueMapMatchedBoundingBox.laneOccupiedRegions = valueMapMatchedBoundingBoxLaneOccupiedRegions;
+  ::ad::map::match::MapMatchedObjectReferencePositionList valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::map::match::MapMatchedPositionConfidenceList valueMapMatchedBoundingBoxReferencePointPositionsElement;
+  ::ad::map::match::MapMatchedPosition valueMapMatchedBoundingBoxReferencePointPositionsElementElement;
+  ::ad::map::match::LanePoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
+  ::ad::map::point::ParaPoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::map::lane::LaneId valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointLaneId(1);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint.laneId
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointLaneId;
+  ::ad::physics::ParametricValue
+    valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointParametricOffset(0.);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint.parametricOffset
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPointParametricOffset;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.paraPoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointParaPoint;
+  ::ad::physics::RatioValue valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLateralT(
+    std::numeric_limits<::ad::physics::RatioValue>::lowest());
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.lateralT
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLateralT;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneLength(-1e9);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.laneLength
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneLength;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneWidth(-1e9);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint.laneWidth
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePointLaneWidth;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.lanePoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementLanePoint;
+  ::ad::map::match::MapMatchedPositionType valueMapMatchedBoundingBoxReferencePointPositionsElementElementType(
+    ::ad::map::match::MapMatchedPositionType::INVALID);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.type
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementType;
+  ::ad::map::point::ECEFPoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointX(
+    -6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint.x
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointX;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointY(
+    -6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint.y
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointY;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointZ(
+    -6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint.z
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointZ;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.matchedPoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPoint;
+  ::ad::physics::Probability valueMapMatchedBoundingBoxReferencePointPositionsElementElementProbability(0.);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.probability
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementProbability;
+  ::ad::map::point::ECEFPoint valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointX(-6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint.x
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointX;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointY(-6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint.y
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointY;
+  ::ad::map::point::ECEFCoordinate valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointZ(-6400000);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint.z
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPointZ;
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.queryPoint
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementQueryPoint;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance(-1e9);
+  valueMapMatchedBoundingBoxReferencePointPositionsElementElement.matchedPointDistance
+    = valueMapMatchedBoundingBoxReferencePointPositionsElementElementMatchedPointDistance;
+  valueMapMatchedBoundingBoxReferencePointPositionsElement.resize(
+    1, valueMapMatchedBoundingBoxReferencePointPositionsElementElement);
+  valueMapMatchedBoundingBoxReferencePointPositions.resize(1, valueMapMatchedBoundingBoxReferencePointPositionsElement);
+  valueMapMatchedBoundingBox.referencePointPositions = valueMapMatchedBoundingBoxReferencePointPositions;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxSamplingDistance(-1e9);
+  valueMapMatchedBoundingBox.samplingDistance = valueMapMatchedBoundingBoxSamplingDistance;
+  ::ad::physics::Distance valueMapMatchedBoundingBoxMatchRadius(-1e9);
+  valueMapMatchedBoundingBox.matchRadius = valueMapMatchedBoundingBoxMatchRadius;
+  value.mapMatchedBoundingBox = valueMapMatchedBoundingBox;
+
+  // override member with data type value above input range maximum
+  ::ad::map::match::MapMatchedObjectBoundingBox invalidInitializedMember;
+  ::ad::physics::Distance invalidInitializedMemberSamplingDistance(1e9 * 1.1);
+  invalidInitializedMember.samplingDistance = invalidInitializedMemberSamplingDistance;
+  value.mapMatchedBoundingBox = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
 }

--- a/ad_map_access/impl/tests/generated/ad/map/route/FullRouteListTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/route/FullRouteListTests.cpp
@@ -1,0 +1,34 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+
+#include <gtest/gtest.h>
+#include <limits>
+#include "ad/map/route/FullRouteList.hpp"
+
+TEST(FullRouteListTests, ostreamOperatorTest)
+{
+  std::stringstream stream;
+  ::ad::map::route::FullRouteList value;
+  stream << value;
+  ASSERT_GT(stream.str().size(), 0u);
+}
+
+#if defined(__clang__) && (__clang_major__ >= 7)
+#pragma GCC diagnostic pop
+#endif

--- a/ad_map_access/impl/tests/generated/ad/map/route/FullRouteListValidInputRangeTests.cpp
+++ b/ad_map_access/impl/tests/generated/ad/map/route/FullRouteListValidInputRangeTests.cpp
@@ -1,0 +1,120 @@
+/*
+ * ----------------- BEGIN LICENSE BLOCK ---------------------------------
+ *
+ * Copyright (C) 2018-2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * ----------------- END LICENSE BLOCK -----------------------------------
+ */
+
+/*
+ * Generated file
+ */
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "ad/map/route/FullRouteListValidInputRange.hpp"
+
+TEST(FullRouteListValidInputRangeTests, testValidInputRangeValidInputRangeMin)
+{
+  ::ad::map::route::FullRouteList value;
+  ASSERT_TRUE(withinValidInputRange(value));
+}
+
+TEST(FullRouteListValidInputRangeTests, testValidInputRangeElementValid)
+{
+  ::ad::map::route::FullRouteList value;
+  ::ad::map::route::FullRoute element;
+  ::ad::map::route::RoadSegmentList elementRoadSegments;
+  ::ad::map::route::RoadSegment elementRoadSegmentsElement;
+  ::ad::map::route::LaneSegmentList elementRoadSegmentsElementDrivableLaneSegments;
+  ::ad::map::route::LaneSegment elementRoadSegmentsElementDrivableLaneSegmentsElement;
+  ::ad::map::lane::LaneId elementRoadSegmentsElementDrivableLaneSegmentsElementLeftNeighbor(1);
+  elementRoadSegmentsElementDrivableLaneSegmentsElement.leftNeighbor
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementLeftNeighbor;
+  ::ad::map::lane::LaneId elementRoadSegmentsElementDrivableLaneSegmentsElementRightNeighbor(1);
+  elementRoadSegmentsElementDrivableLaneSegmentsElement.rightNeighbor
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementRightNeighbor;
+  ::ad::map::lane::LaneIdList elementRoadSegmentsElementDrivableLaneSegmentsElementPredecessors;
+  ::ad::map::lane::LaneId elementRoadSegmentsElementDrivableLaneSegmentsElementPredecessorsElement(1);
+  elementRoadSegmentsElementDrivableLaneSegmentsElementPredecessors.resize(
+    1, elementRoadSegmentsElementDrivableLaneSegmentsElementPredecessorsElement);
+  elementRoadSegmentsElementDrivableLaneSegmentsElement.predecessors
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementPredecessors;
+  ::ad::map::lane::LaneIdList elementRoadSegmentsElementDrivableLaneSegmentsElementSuccessors;
+  ::ad::map::lane::LaneId elementRoadSegmentsElementDrivableLaneSegmentsElementSuccessorsElement(1);
+  elementRoadSegmentsElementDrivableLaneSegmentsElementSuccessors.resize(
+    1, elementRoadSegmentsElementDrivableLaneSegmentsElementSuccessorsElement);
+  elementRoadSegmentsElementDrivableLaneSegmentsElement.successors
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementSuccessors;
+  ::ad::map::route::LaneInterval elementRoadSegmentsElementDrivableLaneSegmentsElementLaneInterval;
+  ::ad::map::lane::LaneId elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalLaneId(1);
+  elementRoadSegmentsElementDrivableLaneSegmentsElementLaneInterval.laneId
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalLaneId;
+  ::ad::physics::ParametricValue elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalStart(0.);
+  elementRoadSegmentsElementDrivableLaneSegmentsElementLaneInterval.start
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalStart;
+  ::ad::physics::ParametricValue elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalEnd(0.);
+  elementRoadSegmentsElementDrivableLaneSegmentsElementLaneInterval.end
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalEnd;
+  bool elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalWrongWay{true};
+  elementRoadSegmentsElementDrivableLaneSegmentsElementLaneInterval.wrongWay
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementLaneIntervalWrongWay;
+  elementRoadSegmentsElementDrivableLaneSegmentsElement.laneInterval
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementLaneInterval;
+  ::ad::map::route::RouteLaneOffset elementRoadSegmentsElementDrivableLaneSegmentsElementRouteLaneOffset(
+    std::numeric_limits<::ad::map::route::RouteLaneOffset>::lowest());
+  elementRoadSegmentsElementDrivableLaneSegmentsElement.routeLaneOffset
+    = elementRoadSegmentsElementDrivableLaneSegmentsElementRouteLaneOffset;
+  elementRoadSegmentsElementDrivableLaneSegments.resize(1, elementRoadSegmentsElementDrivableLaneSegmentsElement);
+  elementRoadSegmentsElement.drivableLaneSegments = elementRoadSegmentsElementDrivableLaneSegments;
+  ::ad::map::route::SegmentCounter elementRoadSegmentsElementSegmentCountFromDestination(
+    std::numeric_limits<::ad::map::route::SegmentCounter>::lowest());
+  elementRoadSegmentsElement.segmentCountFromDestination = elementRoadSegmentsElementSegmentCountFromDestination;
+  ::ad::map::point::BoundingSphere elementRoadSegmentsElementBoundingSphere;
+  ::ad::map::point::ECEFPoint elementRoadSegmentsElementBoundingSphereCenter;
+  ::ad::map::point::ECEFCoordinate elementRoadSegmentsElementBoundingSphereCenterX(-6400000);
+  elementRoadSegmentsElementBoundingSphereCenter.x = elementRoadSegmentsElementBoundingSphereCenterX;
+  ::ad::map::point::ECEFCoordinate elementRoadSegmentsElementBoundingSphereCenterY(-6400000);
+  elementRoadSegmentsElementBoundingSphereCenter.y = elementRoadSegmentsElementBoundingSphereCenterY;
+  ::ad::map::point::ECEFCoordinate elementRoadSegmentsElementBoundingSphereCenterZ(-6400000);
+  elementRoadSegmentsElementBoundingSphereCenter.z = elementRoadSegmentsElementBoundingSphereCenterZ;
+  elementRoadSegmentsElementBoundingSphere.center = elementRoadSegmentsElementBoundingSphereCenter;
+  ::ad::physics::Distance elementRoadSegmentsElementBoundingSphereRadius(-1e9);
+  elementRoadSegmentsElementBoundingSphere.radius = elementRoadSegmentsElementBoundingSphereRadius;
+  elementRoadSegmentsElement.boundingSphere = elementRoadSegmentsElementBoundingSphere;
+  elementRoadSegments.resize(1, elementRoadSegmentsElement);
+  element.roadSegments = elementRoadSegments;
+  ::ad::map::route::RoutePlanningCounter elementRoutePlanningCounter(
+    std::numeric_limits<::ad::map::route::RoutePlanningCounter>::lowest());
+  element.routePlanningCounter = elementRoutePlanningCounter;
+  ::ad::map::route::SegmentCounter elementFullRouteSegmentCount(
+    std::numeric_limits<::ad::map::route::SegmentCounter>::lowest());
+  element.fullRouteSegmentCount = elementFullRouteSegmentCount;
+  ::ad::map::route::RouteLaneOffset elementDestinationLaneOffset(
+    std::numeric_limits<::ad::map::route::RouteLaneOffset>::lowest());
+  element.destinationLaneOffset = elementDestinationLaneOffset;
+  ::ad::map::route::RouteLaneOffset elementMinLaneOffset(
+    std::numeric_limits<::ad::map::route::RouteLaneOffset>::lowest());
+  element.minLaneOffset = elementMinLaneOffset;
+  ::ad::map::route::RouteLaneOffset elementMaxLaneOffset(
+    std::numeric_limits<::ad::map::route::RouteLaneOffset>::lowest());
+  element.maxLaneOffset = elementMaxLaneOffset;
+  ::ad::map::route::RouteCreationMode elementRouteCreationMode(::ad::map::route::RouteCreationMode::Undefined);
+  element.routeCreationMode = elementRouteCreationMode;
+  value.push_back(element);
+  ASSERT_TRUE(withinValidInputRange(value));
+}
+
+TEST(FullRouteListValidInputRangeTests, testValidInputRangeElementInvalid)
+{
+  ::ad::map::route::FullRouteList value;
+  ::ad::map::route::FullRoute element;
+  ::ad::map::route::RouteCreationMode elementRouteCreationMode(static_cast<::ad::map::route::RouteCreationMode>(-1));
+  element.routeCreationMode = elementRouteCreationMode;
+  value.push_back(element);
+  ASSERT_FALSE(withinValidInputRange(value));
+}

--- a/ad_map_access/impl/tests/lane/LaneOperationTests.cpp
+++ b/ad_map_access/impl/tests/lane/LaneOperationTests.cpp
@@ -511,7 +511,7 @@ TEST_F(LaneOperationTest, LaneOperation)
   ASSERT_EQ(calcDuration(laneInt1), physics::Duration(2.));
 }
 
-TEST_F(LaneOperationTest, BoarderOperation)
+TEST_F(LaneOperationTest, BorderOperation)
 {
   ENUEdge edge_enu1, edge_enu2, edge_enu3, edge_enu4;
   ENUBorder border_enu1, border_enu2, border_enu3;
@@ -659,6 +659,12 @@ TEST_F(LaneOperationTest, BoarderOperation)
   ASSERT_GT(calcLength(border_enu1.right), calcLength(border_enu3.right));
   physics::Distance leftedge_length = calcLength(border_enu1.left);
   physics::Distance rightedge_length = calcLength(border_enu1.right);
+
+  auto borderLength = calcLength(border_enu1);
+  ASSERT_EQ(0.5 * (leftedge_length + rightedge_length), borderLength);
+
+  lane::ENUBorderList enuBorderList{border_enu1, border_enu1, border_enu1};
+  ASSERT_EQ(3.0 * borderLength, calcLength(enuBorderList));
 
   edge_enu1.clear();
   edge_enu2.clear();

--- a/ad_map_access/impl/tests/opendrive/OpenDriveAccessTests.cpp
+++ b/ad_map_access/impl/tests/opendrive/OpenDriveAccessTests.cpp
@@ -38,20 +38,24 @@ struct OpenDriveAccessTests : ::testing::Test
   void checkEdgePoints(lane::LaneId laneId, point::ECEFEdge const &edge)
   {
     EXPECT_GE(edge.size(), 2u) << static_cast<uint64_t>(laneId);
-    if (edge.size() == 2u)
+    if (edge.size() > 2u)
     {
-      return;
-    }
-    for (auto pointIter = edge.begin(); pointIter != edge.end(); pointIter++)
-    {
-      auto nextPointIter = pointIter + 1;
-      if (nextPointIter != edge.end())
+      for (auto pointIter = edge.begin(); pointIter != edge.end(); pointIter++)
       {
-        auto deltaPoints = *pointIter - *nextPointIter;
-        auto pointDistance = vectorLength(deltaPoints);
-        EXPECT_NE(pointDistance, physics::Distance(0.)) << static_cast<uint64_t>(laneId) << " num: " << edge.size();
+        auto nextPointIter = pointIter + 1;
+        if (nextPointIter != edge.end())
+        {
+          auto deltaPoints = *pointIter - *nextPointIter;
+          auto pointDistance = vectorLength(deltaPoints);
+          EXPECT_NE(pointDistance, physics::Distance(0.)) << static_cast<uint64_t>(laneId) << " num: " << edge.size();
+        }
       }
     }
+    physics::ParametricRange trange;
+    trange.minimum = physics::ParametricValue(0.);
+    trange.maximum = physics::ParametricValue(1.);
+    auto ecefs = point::getParametricRange(edge, trange);
+    EXPECT_EQ(edge.size(), ecefs.size()) << static_cast<uint64_t>(laneId);
   }
 
   void checkEdgeContacts(lane::Lane const &lane)

--- a/ad_map_access/python/generate_python_lib.py.in
+++ b/ad_map_access/python/generate_python_lib.py.in
@@ -38,9 +38,9 @@ def main():
         ("nullptr", "0"),
         # some renaming for set data types
         ("\"vector_less__ad_scope_map_scope_route_scope_FullRoute__greater_\"", "\"FullRouteList\""),
-	    ("\"vector_less__ad_scope_map_scope_lane_scope_ENUBorder__greater_\"", "\"ENUBorderList\""),
-	    ("\"vector_less__ad_scope_map_scope_lane_scope_ECEFBorder__greater_\"", "\"ECEFBorderList\""),
-	    ("\"vector_less__ad_scope_map_scope_lane_scope_GeoBorder__greater_\"", "\"GeoBorderList\""),
+        ("\"vector_less__ad_scope_map_scope_lane_scope_ENUBorder__greater_\"", "\"ENUBorderList\""),
+        ("\"vector_less__ad_scope_map_scope_lane_scope_ECEFBorder__greater_\"", "\"ECEFBorderList\""),
+        ("\"vector_less__ad_scope_map_scope_lane_scope_GeoBorder__greater_\"", "\"GeoBorderList\""),
         ("\"vector_less__ad_scope_map_scope_lane_scope_LaneId__greater_\"", "\"LaneIdList\""),
         ("\"set_less__ad_scope_map_scope_lane_scope_LaneId__greater_\"", "\"LaneIdSet\""),
         ("\"set_less__ad_scope_map_scope_landmark_scope_LandmarkId__greater_\"", "\"LandmarkIdSet\""),

--- a/ad_map_access_test_support/generated/CMakeLists.txt
+++ b/ad_map_access_test_support/generated/CMakeLists.txt
@@ -14,7 +14,7 @@
 ##
 
 cmake_minimum_required(VERSION 3.5)
-project(ad_map_access_test_support VERSION 2.3.0)
+project(ad_map_access_test_support VERSION 2.3.1)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -31,7 +31,7 @@ if ((NOT ad_map_access_test_support_SOURCES) OR (NOT ad_map_access_test_support_
   message(FATAL_ERROR "${PROJECT_NAME}: Variable ad_map_access_test_support_SOURCES or ad_map_access_test_support_INCLUDE_DIRS pointing to the generator managed library not set!")
 endif()
 
-find_package(ad_map_access 2.3.0 REQUIRED CONFIG)
+find_package(ad_map_access 2.3.1 REQUIRED CONFIG)
 
 add_library(${PROJECT_NAME}
   ${ad_map_access_test_support_SOURCES}

--- a/ad_map_access_test_support/generated/cmake/Config.cmake.in
+++ b/ad_map_access_test_support/generated/cmake/Config.cmake.in
@@ -17,7 +17,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(ad_map_access 2.3.0)
+find_dependency(ad_map_access 2.3.1)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 

--- a/ad_map_access_test_support/generated/include/ad_map_access_test_support/Version.hpp
+++ b/ad_map_access_test_support/generated/include/ad_map_access_test_support/Version.hpp
@@ -30,9 +30,9 @@
 /*!
  * The revision of ad_map_access_test_support
  */
-#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_REVISION 0
+#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_REVISION 1
 
 /*!
  * The version of ad_map_access_test_support as string
  */
-#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_STRING "2.3.0"
+#define AD_MAP_ACCESS_TEST_SUPPORT_VERSION_STRING "2.3.1"

--- a/ad_map_opendrive_reader/src/geometry/GeometryGenerator.cpp
+++ b/ad_map_opendrive_reader/src/geometry/GeometryGenerator.cpp
@@ -684,7 +684,16 @@ void setSuccessorPredecessor(::opendrive::OpenDriveData &mapData,
     if (laneInfo.link->predecessor_id != 0)
     {
       Id predecessorId = laneId(roadInfo.attributes.id, laneSectionIndex - 1, laneInfo.link->predecessor_id);
-      checkAddPredecessor(mapData.laneMap[currentLaneId], mapData.laneMap[predecessorId]);
+      if (mapData.laneMap.find(predecessorId) != mapData.laneMap.end())
+      {
+        checkAddPredecessor(mapData.laneMap[currentLaneId], mapData.laneMap[predecessorId]);
+      }
+      else
+      {
+        std::cerr << "Warning: predecessorId for road " << roadInfo.attributes.id << " lane "
+                  << laneInfo.link->predecessor_id << " and section " << laneSectionIndex - 1 << " does not exist"
+                  << std::endl;
+      }
     }
   }
 

--- a/ad_physics/generated/CMakeLists.txt
+++ b/ad_physics/generated/CMakeLists.txt
@@ -14,7 +14,7 @@
 ##
 
 cmake_minimum_required(VERSION 3.5)
-project(ad_physics VERSION 2.3.0)
+project(ad_physics VERSION 2.3.1)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/ad_physics/generated/include/ad_physics/Version.hpp
+++ b/ad_physics/generated/include/ad_physics/Version.hpp
@@ -30,9 +30,9 @@
 /*!
  * The revision of ad_physics
  */
-#define AD_PHYSICS_VERSION_REVISION 0
+#define AD_PHYSICS_VERSION_REVISION 1
 
 /*!
  * The version of ad_physics as string
  */
-#define AD_PHYSICS_VERSION_STRING "2.3.0"
+#define AD_PHYSICS_VERSION_STRING "2.3.1"

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -117,17 +117,17 @@ Therefore, a full list of step by step calls could look like e.g.:
  # Creating directories
  map$> mkdir install
  map$> mkdir -p build/{proj,spdlog,ad_physics,ad_map_opendrive_reader,ad_map_access}
- 
+
  # Build proj
  map$> cd build/proj
  map/build/proj$> cmake ../../dependencies/PROJ -DCMAKE_INSTALL_PREFIX=../../install/proj -DCMAKE_POSITION_INDEPENDENT_CODE=ON
  map/build/proj$> make install
- 
+
  # Build spdlog
  map$> cd ../spdlog
  map/build/spdlog$> cmake ../../dependencies/spdlog -DCMAKE_INSTALL_PREFIX=../../install/spdlog -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DSPDLOG_BUILD_TESTS=OFF -DSPDLOG_BUILD_EXAMPLE=OFF
  map/build/spdlog$> make install
- 
+
  # Build ad_physics
  map/build/spdlog$> cd ../ad_physics
  map/build/ad_physics$> cmake ../../ad_physics -DCMAKE_INSTALL_PREFIX=../../install/ad_physics -DCMAKE_PREFIX_PATH=../../install/spdlog
@@ -137,7 +137,7 @@ Therefore, a full list of step by step calls could look like e.g.:
  map/build/ad_physics$> cd ../ad_map_opendrive_reader
  map/build/ad_map_opendrive_reader$> cmake ../../ad_map_opendrive_reader -DCMAKE_INSTALL_PREFIX=../../install/ad_map_opendrive_reader -DCMAKE_PREFIX_PATH="../../install/proj;../../install/spdlog;../../install/ad_physics"
  map/build/ad_map_opendrive_reader$> make install
- 
+
  # Build ad_map_access
  map/build/ad_map_opendrive_reader$> cd ../ad_map_access
  map/build/ad_map_access$> cmake ../../ad_map_access -DCMAKE_INSTALL_PREFIX=../../install/ad_map_access -DCMAKE_PREFIX_PATH="../../install/proj;../../install/spdlog;../../install/ad_physics;../../install/ad_map_opendrive_reader"

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,8 +9,18 @@
    - Settings for Route Prediction test,Routing Test at run time.
    - For open drive map, the attributes roadId, laneSectionIndex and laneIndex are added.
    - The ENU coordinates of the map snapped point is added as an attribute.
+* Added AdMapMatching::findRouteLanes()
+* Added lane::findNearestPointOnLaneInterval()
+* Added matchRadius and samplingDistance members to match::MapMatchedObjectBoundingBox
+
 #### :ghost: Maintenance
 * Use target python version for build
+* Generate list types and tests: ENUBorderList, GeoBorderList, ECEFBorderList,
+  FullRouteList, MapMatchedObjectReferencePositionList
+* Fixed issue in reading of some OpenDRIVE maps
+* Fixed lane::calcLength(<ENU,ECEF,Geo>BorderList) functions
+* Allow rounding errors in lane::isPointWithinBorderPoints() (might e.g. happen after projection of outside points onto the borders)
+* Fix route::planning::createRoutingPoint(match::LaneOccupiedRegion)
 
 ## Release 2.3.0
 #### :rocket: New Features

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Generate list types and tests: ENUBorderList, GeoBorderList, ECEFBorderList,
   FullRouteList, MapMatchedObjectReferencePositionList
 * Fixed issue in reading of some OpenDRIVE maps
+* Fixed point::getParametricRange() for degenerated edges
 * Fixed lane::calcLength(<ENU,ECEF,Geo>BorderList) functions
 * Allow rounding errors in lane::isPointWithinBorderPoints() (might e.g. happen after projection of outside points onto the borders)
 * Fix route::planning::createRoutingPoint(match::LaneOccupiedRegion)

--- a/tools/ad_map_access_qgis/LandmarkRunnerGeneric.py
+++ b/tools/ad_map_access_qgis/LandmarkRunnerGeneric.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/LaneRunnerSpeed.py
+++ b/tools/ad_map_access_qgis/LaneRunnerSpeed.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/LaneRunnerSurface.py
+++ b/tools/ad_map_access_qgis/LaneRunnerSurface.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/LayerManagerLaneSurface.py
+++ b/tools/ad_map_access_qgis/LayerManagerLaneSurface.py
@@ -34,8 +34,8 @@ class LayerManagerLaneSurface(LayerManager):
         attrs.append(str(lane.type))
         attrs.append(str(ad.map.lane.getHOV(lane)))
         if lane_id_int > 10000:
-            attrs.append(int(lane_id_int/10000))
-            attrs.append(int((lane_id_int % 10000)/100))
+            attrs.append(int(lane_id_int / 10000))
+            attrs.append(int((lane_id_int % 10000) / 100))
             attrs.append((lane_id_int % 10000) % 100)
         feature = self.layer.add_lla2(lla_left, lla_right, attrs)
         LayerManager.add_new_feature(self, lane_id, feature)

--- a/tools/ad_map_access_qgis/Logger.py
+++ b/tools/ad_map_access_qgis/Logger.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/MapSnappingTest.py
+++ b/tools/ad_map_access_qgis/MapSnappingTest.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/QGISLayer.py
+++ b/tools/ad_map_access_qgis/QGISLayer.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/QGISUI.py
+++ b/tools/ad_map_access_qgis/QGISUI.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/Runner.py
+++ b/tools/ad_map_access_qgis/Runner.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/Worker.py
+++ b/tools/ad_map_access_qgis/Worker.py
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tools/ad_map_access_qgis/__init__.py
+++ b/tools/ad_map_access_qgis/__init__.py
@@ -36,7 +36,7 @@ def classFactory(iface):  # pylint: disable=invalid-name
     Globs.iface = iface
     Globs.log = Logger.LoggerQgs(iface)
     # If the console logger is needed then the below line can be uncommented to observe the log messages on the console.
-    #Globs.log = Logger.LoggerConsole(iface)
+    # Globs.log = Logger.LoggerConsole(iface)
 
     Globs.main = Main()
     return Globs.main


### PR DESCRIPTION
Some fixes:
- Fixed issue in reading OpenDRIVE maps
- Fixed point::getParametricRange() for degenerated edges
- Fixed lane::calcLength(<ENU,ECEF,Geo>BorderList) functions
- Allow rounding errors in lane::isPointWithinBorderPoints() (might e.g.
happen after projection of outside points onto the borders)
- Fix route::planning::createRoutingPoint(match::LaneOccupiedRegion)

New features:
- Added AdMapMatching::findRouteLanes()
- Added lane::findNearestPointOnLaneInterval()
- Added matchRadius and samplingDistance members to
    match::MapMatchedObjectBoundingBox
- Generate list types and tests: ENUBorderList, GeoBorderList,
ECEFBorderList, FullRouteList, MapMatchedObjectReferencePositionList

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/map/33)
<!-- Reviewable:end -->
