### PR TITLE
Fix edge normalization on OpenDRIVE import

### DIFF
--- a/ad_map_access/impl/tests/route/LaneIntervalOperationTest.cpp
+++ b/ad_map_access/impl/tests/route/LaneIntervalOperationTest.cpp
@@ -293,7 +293,7 @@ TEST_F(LaneIntervalOperationTest, GetProjectedENUEdgeOnTown01)
   ASSERT_TRUE(access::init("test_files/Town01.txt"));
 
   ENUPoint point_edu1 = createENUPoint(4.453, -4.560, 0);
-  ASSERT_NEAR((double)lane::calcWidth(point_edu1), 3.9986, 0.0001);
+  ASSERT_NEAR((double)lane::calcWidth(point_edu1), 3.99, 0.0001);
   GeoPoint point_geo1 = toGeo(point_edu1);
   auto startLaneId = lane::uniqueLaneId(point_geo1);
   laneInt1.laneId = startLaneId;

--- a/ad_map_opendrive_reader/include/opendrive/geometry/Geometry.hpp
+++ b/ad_map_opendrive_reader/include/opendrive/geometry/Geometry.hpp
@@ -66,7 +66,7 @@ class Geometry
 {
 public:
   // max sampling error expected
-  static constexpr double cMaxSamplingError = 1e-2;
+  static constexpr double cMaxSamplingError = 5e-2;
 
   /**
    * @brief Returns the GeometryType associated to this geometry.


### PR DESCRIPTION
normalizeEdge()
- prevent form dropping edge end point
- restrict to x/y-plane
- prevent from unnecessary calls

Allow for sampling errors up to 5cm to prevent from getting too much
sampling points.

Change-Id: I33013e2eab73f055be5d965778f9a21adee22fe4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/map/61)
<!-- Reviewable:end -->
