### PR TITLE
Route planning fixes and extensions

### DIFF
--- a/ad_map_access/impl/ad_map_access.cmake
+++ b/ad_map_access/impl/ad_map_access.cmake
@@ -1,6 +1,6 @@
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #
@@ -18,6 +18,7 @@ set(ad_map_access_SOURCES
   ${CMAKE_CURRENT_LIST_DIR}/src/access/Store.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/access/StoreSerialization.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/config/MapConfigFileHandler.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/intersection/CoreIntersection.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/intersection/Intersection.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/landmark/LandmarkOperation.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/lane/BorderOperation.cpp
@@ -73,4 +74,3 @@ set(ad_map_access_UNIT_TEST_DIR
 #set(ad_map_access_TOOLS_DIR
 #  ${CMAKE_CURRENT_LIST_DIR}/tools
 #)
-

--- a/ad_map_access/impl/include/ad/map/intersection/CoreIntersection.hpp
+++ b/ad_map_access/impl/include/ad/map/intersection/CoreIntersection.hpp
@@ -1,0 +1,355 @@
+// ----------------- BEGIN LICENSE BLOCK ---------------------------------
+//
+// Copyright (C) 2018-2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+//
+// ----------------- END LICENSE BLOCK -----------------------------------
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+#include "ad/map/lane/Types.hpp"
+#include "ad/map/match/Types.hpp"
+#include "ad/map/point/Types.hpp"
+#include "ad/map/route/RouteOperation.hpp"
+
+/** @brief namespace ad */
+namespace ad {
+/** @brief namespace map */
+namespace map {
+/** @brief namespace intersection */
+namespace intersection {
+
+/**
+ * @brief forward declaration of CoreIntersection class
+ */
+class CoreIntersection;
+
+/**
+ * @brief typedef for shared_ptr of CoreIntersection class
+ */
+typedef std::shared_ptr<CoreIntersection> CoreIntersectionPtr;
+
+/**
+ * @brief typedef for shared_ptr of const CoreIntersection class
+ */
+typedef std::shared_ptr<CoreIntersection const> CoreIntersectionConstPtr;
+
+/**
+ * Class to provide basic intersection information.
+ *
+ *  The CoreIntersection class provides:
+ *  - the list of all lanes of the intersection and their extends (see CoreIntersection::internalLanes() and
+ * CoreIntersection::getBoundingSphere())
+ *  - the list of lanes entering the intersection (see CoreIntersection::entryLanes() and
+ * CoreIntersection::entryParaPoints())
+ *  - the list of lanes exiting the intersection (see CoreIntersection::exitLanes() and
+ * CoreIntersection::exitParaPoints())
+ *  - supporting functions to check how lanes, routes, objects are interacting with the intersection
+ */
+class CoreIntersection
+{
+public:
+  /**
+   * @brief check if a lane is part of any intersection
+   */
+  static bool isLanePartOfAnIntersection(lane::LaneId const laneId);
+
+  /**
+   * @brief check if any lane in the route is part of any intersection
+   *
+   * @param[in] route planned route
+   *
+   * @return If there is an intersection within the route, \c true is returned.
+   */
+  static bool isRoutePartOfAnIntersection(route::FullRoute const &route);
+
+  /**
+   * @brief check if there is an intersection for the given route
+   *
+   * @param[in] route planned route
+   *
+   * @return If there is an intersection within the route, \c true is returned.
+   */
+  static bool isIntersectionOnRoute(route::FullRoute const &route);
+
+  /**
+   * @brief check if the road segment enters an intersection
+   *
+   * @param[in] routeIterator the route iterator of the road segment
+   * @param[out] routePreviousSegmentIter if an intersectin is entered,
+   *   this holds the previous route segment that is part of the transition
+   *
+   * @returns \c true if given routeIterator enters an intersection
+   */
+  static bool isRoadSegmentEnteringIntersection(route::RouteIterator const &routeIterator,
+                                                route::RoadSegmentList::const_iterator &routePreviousSegmentIter);
+
+  /**
+   * @returns \c true if the provided \c objectRoute contains an internal lane
+   *
+   * This is the case if one of the internalLanes()
+   * is part of the objectRoute.
+   */
+  bool objectRouteCrossesIntersection(route::FullRoute const &objectRoute) const;
+
+  /** @brief calculate and return the physics::Distance of the object to the intersection */
+  physics::Distance objectDistanceToIntersection(match::Object const &object) const;
+
+  /** @returns \c true if the object is within the intersection (touches one of the internalLanes) */
+  bool objectWithinIntersection(match::MapMatchedObjectBoundingBox const &object) const;
+
+  /** @return all lanes that are inside the intersection (independent of route) */
+  lane::LaneIdSet const &internalLanes() const;
+
+  /** @return all lanes that lead into the intersection  (not part of the intersection themselves) */
+  lane::LaneIdSet const &entryLanes() const;
+
+  /** @return the border points of all lanes that lead into the intersection as ParaPoint's */
+  point::ParaPointList const &entryParaPoints() const;
+
+  /** @return all lanes that lead out of the intersection (not part of the intersection themselves) */
+  lane::LaneIdSet const &exitLanes() const;
+
+  /** @return the border points of all lanes that lead out of the intersection as ParaPoint's */
+  point::ParaPointList const &exitParaPoints() const;
+
+  /** @return the bounding sphere of all the inner lanes of the intersection **/
+  point::BoundingSphere const &getBoundingSphere() const
+  {
+    return mInternalLanesBoundingSphere;
+  }
+
+  /**
+   * @brief retrieve the core intersection for the given laneId
+   *
+   * @param[in] laneId the laneId to use for creation of the CoreIntersection
+   *
+   * @return if the provided \a laneId is part of an intersection a CoreIntersection object is created and returned.
+   */
+  static CoreIntersectionPtr getCoreIntersectionFor(lane::LaneId const &laneId);
+
+  /**
+   * @brief retrieve all CoreIntersection objects for the given lane Ids
+   *
+   * @param[in] laneIds the set of laneIds to use for creation of the CoreIntersection
+   *
+   * @return if one of the provided lane Ids is part of an intersection a CoreIntersection object is created and
+   * returned.
+   * if multiple lane Ids are part of the same CoreIntersection only one single CoreIntersection is returned.
+   * if lane Ids are part of different CoreIntersections, multiple CoreIntersections are returned.
+   * In summary: the CoreIntersections of all lanedIds are returned, so that
+   * every laneId of the provided \a laneIds set that belongs to an intersection is present in one of the returned
+   * CoreIntersection::internalLanes() set.
+   */
+  static std::vector<CoreIntersectionPtr> getCoreIntersectionsFor(lane::LaneIdSet const &laneIds);
+
+  /**
+   * @brief retrieve all CoreIntersection objects for the given lane Ids
+   *
+   * @param[in] laneIds the vector of laneIds to use for creation of the CoreIntersection
+   *
+   * @return if one of the provided lane Ids is part of an intersection a CoreIntersection object is created and
+   * returned.
+   * if multiple lane Ids are part of the same CoreIntersection only one single CoreIntersection is returned.
+   * if lane Ids are part of different CoreIntersections, multiple CoreIntersections are returned.
+   * In summary: the CoreIntersections of all lanedIds are returned, so that
+   * every laneId of the provided \a laneIds set that belongs to an intersection is present in one of the returned
+   * CoreIntersection::internalLanes() set.
+   */
+  static std::vector<CoreIntersectionPtr> getCoreIntersectionsFor(lane::LaneIdList const &laneIds);
+
+  /**
+   * @brief retrieve all CoreIntersection objects of the map
+   *
+   * @return getCoreIntersectionsFor(lane::getLanes())
+   */
+  static std::vector<CoreIntersectionPtr> getCoreIntersectionsForMap();
+
+  /**
+   * @brief retrieve the core intersection for the given mapMatchedPosition
+   *
+   * @returns getCoreIntersectionFor(mapMatchedPosition.lanePoint.paraPoint.laneId)
+   **/
+  static CoreIntersectionPtr getCoreIntersectionFor(match::MapMatchedPosition const &mapMatchedPosition);
+
+  /**
+   * @brief retrieve the core intersection for the given ENU \a position
+   *
+   * Performs map matching of the given \a position and
+   * returns getCoreIntersectionsForInLaneMatches(MapMatchedPositionConfidenceList) of the matching result.
+   */
+  static std::vector<CoreIntersectionPtr> getCoreIntersectionsForInLaneMatches(point::ENUPoint const &position);
+
+  /**
+   * @brief retrieve the core intersection for the given mapMatchedPositionConfidenceList
+   *
+   * Collects all in lane matches part of the \a mapMatchedPositionConfidenceList in a LaneIdSet and returns the vector
+   *of CoreIntersection
+   * returned by getCoreIntersectionsFor(laneIdSet).
+   * Usually the result vector size is zero or one. In cases where multiple intersections are on top of each other and
+   *the map matching
+   * distance exceeded the altitude difference of the intersections, multiple CoreIntersection results are possible.
+   **/
+  static std::vector<CoreIntersectionPtr>
+  getCoreIntersectionsForInLaneMatches(match::MapMatchedPositionConfidenceList const &mapMatchedPositionConfidenceList);
+
+  /**
+   * @brief retrieve the core intersection for the given object
+   *
+   * @returns Collects all in lane matches part of the \a MapMatchedObjectBoundingBox in a LaneIdSet and returns the
+   *vector of CoreIntersection
+   * returned by getCoreIntersectionsFor(laneIdSet).
+   * Usually the result vector size is zero or one. In cases where multiple intersections are on top of each other and
+   *the map matching
+   * distance exceeded the altitude difference of the intersections, multiple CoreIntersection results are possible.
+   **/
+  static std::vector<CoreIntersectionPtr>
+  getCoreIntersectionsForInLaneMatches(match::MapMatchedObjectBoundingBox const &object);
+
+protected:
+  CoreIntersection() = default;
+
+  //! check if given lane is inside the intersection
+  bool isLanePartOfCoreIntersection(lane::LaneId const laneId) const;
+
+  void extractLanesOfCoreIntersection(lane::LaneId const laneId);
+
+  enum SuccessorMode
+  {
+    OwnIntersection,
+    AnyIntersection
+  };
+
+  bool isLanePartOfIntersection(lane::LaneId const laneId, SuccessorMode const successorMode) const;
+
+  /**
+   * @brief Provide the direct successor lane segments in lane direction within and outside of the intersection.
+   *
+   * @param laneId LaneId
+   * @return a pair with <the laneID segments within the intersection, the laneID segments outside the intersection>
+   */
+  std::pair<lane::LaneIdSet, lane::LaneIdSet>
+  getDirectSuccessorsInLaneDirection(lane::LaneId const laneId, SuccessorMode const successorMode) const;
+
+  /**
+   * @brief Provide the direct successor lane segments in lane direction within the intersection.
+   *
+   * @param laneId LaneId
+   * @return the laneID segments within the intersection.
+   */
+  lane::LaneIdSet getDirectSuccessorsInLaneDirectionWithinIntersection(lane::LaneId const laneId,
+                                                                       SuccessorMode const successorMode) const;
+
+  /**
+   * @brief Provide the successor lane segments in lane direction within the intersection recursively until the
+   * intersection is left
+   *
+   * @param laneId LaneId
+   * @return the laneID segments within the intersection.
+   */
+  lane::LaneIdSet getAllSuccessorsInLaneDirectionWithinIntersection(lane::LaneId const laneId,
+                                                                    SuccessorMode const successorMode) const;
+
+  /**
+   * @brief Provide the successor lane segments in lane direction within the intersection recursively until the
+   * intersection is left including the input laneId if part of the inner lanes.
+   *
+   * @param laneId LaneId
+   * @return the laneID segments within the intersection.
+   */
+  lane::LaneIdSet getLaneAndAllSuccessorsInLaneDirectionWithinIntersection(lane::LaneId const laneId,
+                                                                           SuccessorMode const successorMode) const;
+
+  /**
+   * @brief Provide the outgoing lane segments that are reachable in lane direction
+   *
+   * @param laneId LaneId
+   * @return the outgoing laneID segments outside the intersection.
+   */
+  lane::LaneIdSet getAllReachableOutgoingLanes(lane::LaneId const laneId, SuccessorMode const successorMode) const;
+
+  /**
+   * @brief Provide the outgoing lane segments that are reachable in lane direction as well as the intersection internal
+   * lanes
+   *
+   * @param laneId LaneId
+   * @return a pair with <the laneID segments within the intersection, the laneID segments outside the intersection>
+   */
+  std::pair<lane::LaneIdSet, lane::LaneIdSet>
+  getAllReachableInternalAndOutgoingLanes(lane::LaneId const laneId, SuccessorMode const successorMode) const;
+
+  point::ParaPoint getEntryParaPointOfExternalLane(lane::LaneId const &laneId) const;
+  point::ParaPoint getExitParaPointOfExternalLane(lane::LaneId const &laneId) const;
+  point::ParaPoint getEntryParaPointOfInternalLane(lane::LaneId const &laneId) const;
+  point::ParaPoint getExitParaPointOfInternalLane(lane::LaneId const &laneId) const;
+
+  //! all lanes inside the intersection
+  lane::LaneIdSet mInternalLanes{};
+
+  //! lanes going into the intersection
+  lane::LaneIdSet mEntryLanes{};
+
+  //! lanes going into the intersection represented as ParaPoint
+  point::ParaPointList mEntryParaPoints{};
+
+  //! lanes going out of the intersection
+  lane::LaneIdSet mExitLanes{};
+
+  //! lanes going out of the intersection represented as ParaPoint
+  point::ParaPointList mExitParaPoints{};
+
+  /**
+   * Managing relations between lanes through separate maps with sets. Reading:
+   * key: id of lane
+   * value: set of lanes that relate with this one (e.g. overlap)
+   */
+  std::map<lane::LaneId, lane::LaneIdSet> mOverlapping;
+  std::map<lane::LaneId, lane::LaneIdSet> mSuccessor;
+  std::map<lane::LaneId, lane::LaneIdSet> mPredecessor;
+
+  point::BoundingSphere mInternalLanesBoundingSphere;
+
+private:
+  explicit CoreIntersection(lane::LaneId const &laneId);
+
+  void checkAndInsertEntryLane(lane::LaneId const laneId);
+  void checkAndInsertExitLane(lane::LaneId const laneId);
+  void processContactsForLane(lane::Lane const &lane, lane::ContactLane const &contact);
+
+  template <typename CONTAINER>
+  static std::vector<CoreIntersectionPtr> getCoreIntersectionsForLaneIds(CONTAINER const &laneIds);
+};
+
+} // namespace intersection
+} // namespace map
+} // namespace ad
+
+namespace std {
+
+/**
+ * \brief standard ostream operator for ad::map::intersection::CoreIntersection
+ *
+ * \param[in] os The output stream to write to
+ * \param[in] intersection The core intersection object
+ *
+ * \returns The stream object.
+ *
+ */
+std::ostream &operator<<(std::ostream &os, ::ad::map::intersection::CoreIntersection const &intersection);
+
+/**
+ * \brief overload of the std::to_string for ad::map::intersection::CoreIntersection
+ */
+static inline std::string to_string(::ad::map::intersection::CoreIntersection const &intersection)
+{
+  stringstream sstream;
+  sstream << intersection;
+  return sstream.str();
+}
+} // namespace std

--- a/ad_map_access/impl/include/ad/map/lane/LaneOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/lane/LaneOperation.hpp
@@ -488,6 +488,14 @@ struct LaneAltitudeRange
  * @returns The range of the lanes altitude
  */
 LaneAltitudeRange calcLaneAltitudeRange(Lane const &lane);
+
+/**
+ * @brief Checks if the laneId is relevant for expansion given the set of relevant lanes.
+ *
+ * @returns \c true if the \a relevantLanes set is empty, or if the laneId can be found in the set of \a relevantLanes.
+ */
+bool isLaneRelevantForExpansion(lane::LaneId const &laneId, lane::LaneIdSet const &relevantLanes);
+
 } // namespace lane
 } // namespace map
 } // namespace ad

--- a/ad_map_access/impl/include/ad/map/match/AdMapMatching.hpp
+++ b/ad_map_access/impl/include/ad/map/match/AdMapMatching.hpp
@@ -14,11 +14,11 @@
 #include "ad/map/point/Operation.hpp"
 #include "ad/map/route/Types.hpp"
 
-/* @brief namespace admap */
+/** @brief namespace admap */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace match */
+/** @brief namespace match */
 namespace match {
 
 /**
@@ -145,6 +145,23 @@ public:
   }
 
   /**
+   * @brief set the lanes that are relevant for map matching
+   * All the rest of the lanes in the map are ignored.
+   */
+  void setRelevantLanes(::ad::map::lane::LaneIdSet const &relevantLanes)
+  {
+    mRelevantLanes = relevantLanes;
+  }
+
+  /**
+   * @brief clear the list of relevant lanes.
+   */
+  void clearRelevantLanes()
+  {
+    mRelevantLanes.clear();
+  }
+
+  /**
    * @brief get the map matched positions
    *
    * Calculate the map matched positions and return these.
@@ -257,13 +274,16 @@ public:
    *        from given point.
    * @param[in] ecefPoint Point that is used as base for the search.
    * @param[in] distance Search radius.
+   * @param[in] relevantLanes if not empty, the function restricts the search to the given set of lanes
    *
    * This static function doesn't make use of any matching hints.
    *
    * @returns Map matching results that satisfy search criteria.
    */
   static MapMatchedPositionConfidenceList findLanes(point::ECEFPoint const &ecefPoint,
-                                                    physics::Distance const &distance);
+                                                    physics::Distance const &distance,
+                                                    ::ad::map::lane::LaneIdSet const &relevantLanes
+                                                    = ::ad::map::lane::LaneIdSet());
 
   /**
    * @brief Spatial Lane Search.
@@ -271,12 +291,16 @@ public:
    *        from given point.
    * @param[in] geoPoint Point that is used as base for the search.
    * @param[in] distance Search radius.
+   * @param[in] relevantLanes if not empty, the function restricts the search to the given set of lanes
    *
    * This static function doesn't make use of any matching hints.
    *
    * @returns Map matching results that satisfy search criteria. The individual matching result probabilities are equal.
    */
-  static MapMatchedPositionConfidenceList findLanes(point::GeoPoint const &geoPoint, physics::Distance const &distance);
+  static MapMatchedPositionConfidenceList findLanes(point::GeoPoint const &geoPoint,
+                                                    physics::Distance const &distance,
+                                                    ::ad::map::lane::LaneIdSet const &relevantLanes
+                                                    = ::ad::map::lane::LaneIdSet());
 
   /**
    * @brief Spatial Lane Search.
@@ -300,7 +324,8 @@ private:
   AdMapMatching &operator=(AdMapMatching const &) = delete;
 
   static match::MapMatchedPositionConfidenceList findLanesInputChecked(point::ECEFPoint const &ecefPoint,
-                                                                       physics::Distance const &distance);
+                                                                       physics::Distance const &distance,
+                                                                       ::ad::map::lane::LaneIdSet const &relevantLanes);
 
   static match::MapMatchedPositionConfidenceList
   findLanesInputChecked(std::vector<lane::Lane::ConstPtr> const &relevantLanes,
@@ -313,7 +338,14 @@ private:
                                physics::Probability const &probabilitySum);
 
   static match::MapMatchedPositionConfidenceList
-  findLanesInputCheckedAltitudeUnknown(point::GeoPoint const &geoPoint, physics::Distance const &distance);
+  findLanesInputCheckedAltitudeUnknown(point::GeoPoint const &geoPoint,
+                                       physics::Distance const &distance,
+                                       ::ad::map::lane::LaneIdSet const &relevantLanes);
+
+  static std::vector<lane::Lane::ConstPtr>
+  getRelevantLanesInputChecked(point::ECEFPoint const &ecefPoint,
+                               physics::Distance const &distance,
+                               ::ad::map::lane::LaneIdSet const &relevantLanes);
 
   /**
    * @brief extract the mapMatchedPositions and write them into a map of occuppied regions
@@ -336,6 +368,8 @@ private:
   double mHeadingHintFactor{2.};
   std::list<route::FullRoute> mRouteHints;
   double mRouteHintFactor{10.};
+
+  ::ad::map::lane::LaneIdSet mRelevantLanes;
 };
 
 } // namespace match

--- a/ad_map_access/impl/include/ad/map/match/MapMatchedOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/match/MapMatchedOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -11,11 +11,11 @@
 #include "ad/map/match/Types.hpp"
 #include "ad/map/point/Types.hpp"
 
-/* @brief namespace admap */
+/** @brief namespace admap */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace match */
+/** @brief namespace match */
 namespace match {
 
 /** @brief get the list of ParaPoints out of the map matched positions */

--- a/ad_map_access/impl/include/ad/map/point/BoundingSphereOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/point/BoundingSphereOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2019 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -23,7 +23,7 @@ namespace point {
 inline physics::Distance distance(BoundingSphere const &left, BoundingSphere const &right)
 {
   physics::Distance const distanceCenter = distance(left.center, right.center);
-  return std::max(physics::Distance(0u), distanceCenter - left.radius - right.radius);
+  return std::max(physics::Distance(0.), distanceCenter - left.radius - right.radius);
 }
 
 /**

--- a/ad_map_access/impl/include/ad/map/point/CoordinateTransform.hpp
+++ b/ad_map_access/impl/include/ad/map/point/CoordinateTransform.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -12,11 +12,11 @@
 #include <vector>
 #include "ad/map/point/Types.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace point */
+/** @brief namespace point */
 namespace point {
 
 /**

--- a/ad_map_access/impl/include/ad/map/point/EdgeOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/point/EdgeOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -17,11 +17,11 @@
 #include "ad/physics/ParametricValueValidInputRange.hpp"
 #include "ad/physics/RangeOperation.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace point */
+/** @brief namespace point */
 namespace point {
 
 /**

--- a/ad_map_access/impl/include/ad/map/point/GeoOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/point/GeoOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2019 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -13,11 +13,11 @@
 #include "ad/map/point/PointOperation.hpp"
 #include "ad/physics/Distance.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace point */
+/** @brief namespace point */
 namespace point {
 
 /**

--- a/ad_map_access/impl/include/ad/map/point/GeometryOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/point/GeometryOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2019 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -15,11 +15,11 @@
 #include "ad/map/point/Geometry.hpp"
 #include "ad/physics/ParametricRange.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace point */
+/** @brief namespace point */
 namespace point {
 
 /**

--- a/ad_map_access/impl/include/ad/map/point/PointOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/point/PointOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -16,11 +16,11 @@
 #include "ad/physics/ParametricValue.hpp"
 #include "ad/physics/RatioValue.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace point */
+/** @brief namespace point */
 namespace point {
 
 /**

--- a/ad_map_access/impl/include/ad/map/point/Transform.hpp
+++ b/ad_map_access/impl/include/ad/map/point/Transform.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2019 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -12,11 +12,11 @@
 #include "ad/map/point/CoordinateTransform.hpp"
 #include "ad/map/point/Types.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace point */
+/** @brief namespace point */
 namespace point {
 
 /**

--- a/ad_map_access/impl/include/ad/map/route/LaneIntervalOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/route/LaneIntervalOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -12,11 +12,11 @@
 #include "ad/map/lane/Types.hpp"
 #include "ad/map/route/Types.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace route */
+/** @brief namespace route */
 namespace route {
 
 /**

--- a/ad_map_access/impl/include/ad/map/route/Planning.hpp
+++ b/ad_map_access/impl/include/ad/map/route/Planning.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -15,11 +15,11 @@
 #include "ad/map/route/Routing.hpp"
 #include "ad/map/route/Types.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace route */
+/** @brief namespace route */
 namespace route {
 /**
  * @namespace planning
@@ -250,6 +250,24 @@ inline route::FullRoute planRoute(const point::ParaPoint &start,
   return planRoute(createRoutingPoint(start, startHeading), dest, routeCreationMode);
 }
 
+/** @brief mode for filtering duplicates in prediction
+ */
+enum class FilterDuplicatesMode
+{
+  /** no filtering at all
+   */
+  Off,
+  /** filter routes that are exactly equal
+   */
+  OnlyEqual,
+  /** filter real sub-routes, prefer shorter ones
+   */
+  SubRoutesPreferShorterOnes,
+  /** filter real sub-routes, prefer longer ones
+   */
+  SubRoutesPreferLongerOnes
+};
+
 /**
  * @brief perform route based prediction restricted by the prediction duration.
  * Note: Route predictions will not stop in the middle of an intersection.
@@ -258,13 +276,17 @@ inline route::FullRoute planRoute(const point::ParaPoint &start,
  * @param[in] start start point.
  * @param[in] predictionDuration duration when the prediction can be stopped.
  * @param[in] routeCreationMode the mode of creating the route (default: RouteCreationMode::SameDrivingDirection)
+ * @param[in] filterMode the mode for filtering the routes (default: FilterDuplicatesMode::SubRoutesPreferLongerOnes)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  *
  * @return vector with all possible predicted routes.
  */
-std::vector<route::FullRoute> predictRoutesOnDuration(const RoutingParaPoint &start,
-                                                      physics::Duration const &predictionDuration,
-                                                      RouteCreationMode const routeCreationMode
-                                                      = RouteCreationMode::SameDrivingDirection);
+std::vector<route::FullRoute>
+predictRoutesOnDuration(const RoutingParaPoint &start,
+                        physics::Duration const &predictionDuration,
+                        RouteCreationMode const routeCreationMode = RouteCreationMode::SameDrivingDirection,
+                        FilterDuplicatesMode const filterMode = FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+                        ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief perform route based prediction restricted by the prediction distance.
@@ -274,13 +296,17 @@ std::vector<route::FullRoute> predictRoutesOnDuration(const RoutingParaPoint &st
  * @param[in] start start point.
  * @param[in] predictionDistance distance when the prediction can be stopped.
  * @param[in] routeCreationMode the mode of creating the route (default: RouteCreationMode::SameDrivingDirection)
+ * @param[in] filterMode the mode for filtering the routes (default: FilterDuplicatesMode::SubRoutesPreferLongerOnes)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  *
  * @return vector with all possible predicted routes.
  */
-std::vector<route::FullRoute> predictRoutesOnDistance(const RoutingParaPoint &start,
-                                                      physics::Distance const &predictionDistance,
-                                                      RouteCreationMode const routeCreationMode
-                                                      = RouteCreationMode::SameDrivingDirection);
+std::vector<route::FullRoute>
+predictRoutesOnDistance(const RoutingParaPoint &start,
+                        physics::Distance const &predictionDistance,
+                        RouteCreationMode const routeCreationMode = RouteCreationMode::SameDrivingDirection,
+                        FilterDuplicatesMode const filterMode = FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+                        ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief perform route based prediction restricted by the prediction distance and duration.
@@ -291,14 +317,18 @@ std::vector<route::FullRoute> predictRoutesOnDistance(const RoutingParaPoint &st
  * @param[in] predictionDistance distance when the prediction can be stopped.
  * @param[in] predictionDuration duration when the prediction can be stopped.
  * @param[in] routeCreationMode the mode of creating the route (default: RouteCreationMode::SameDrivingDirection)
+ * @param[in] filterMode the mode for filtering the routes (default: FilterDuplicatesMode::SubRoutesPreferLongerOnes)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  *
  * @return vector with all possible predicted routes.
  */
-std::vector<route::FullRoute> predictRoutes(const RoutingParaPoint &start,
-                                            physics::Distance const &predictionDistance,
-                                            physics::Duration const &predictionDuration,
-                                            RouteCreationMode const routeCreationMode
-                                            = RouteCreationMode::SameDrivingDirection);
+std::vector<route::FullRoute>
+predictRoutes(const RoutingParaPoint &start,
+              physics::Distance const &predictionDistance,
+              physics::Duration const &predictionDuration,
+              RouteCreationMode const routeCreationMode = RouteCreationMode::SameDrivingDirection,
+              FilterDuplicatesMode const filterMode = FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+              ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief perform route based prediction restricted by the prediction duration.
@@ -308,13 +338,17 @@ std::vector<route::FullRoute> predictRoutes(const RoutingParaPoint &start,
  * @param[in] start start point as map matched bounding box.
  * @param[in] predictionDuration duration when the prediction can be stopped.
  * @param[in] routeCreationMode the mode of creating the route (default: RouteCreationMode::SameDrivingDirection)
+ * @param[in] filterMode the mode for filtering the routes (default: FilterDuplicatesMode::SubRoutesPreferLongerOnes)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  *
  * @return vector with all possible predicted routes.
  */
-std::vector<route::FullRoute> predictRoutesOnDuration(const match::MapMatchedObjectBoundingBox &start,
-                                                      physics::Duration const &predictionDuration,
-                                                      RouteCreationMode const routeCreationMode
-                                                      = RouteCreationMode::SameDrivingDirection);
+std::vector<route::FullRoute>
+predictRoutesOnDuration(const match::MapMatchedObjectBoundingBox &start,
+                        physics::Duration const &predictionDuration,
+                        RouteCreationMode const routeCreationMode = RouteCreationMode::SameDrivingDirection,
+                        FilterDuplicatesMode const filterMode = FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+                        ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief perform route based prediction restricted by the prediction distance.
@@ -324,13 +358,17 @@ std::vector<route::FullRoute> predictRoutesOnDuration(const match::MapMatchedObj
  * @param[in] start start point as map matched bounding box.
  * @param[in] predictionDistance distance when the prediction can be stopped.
  * @param[in] routeCreationMode the mode of creating the route (default: RouteCreationMode::SameDrivingDirection)
+ * @param[in] filterMode the mode for filtering the routes (default: FilterDuplicatesMode::SubRoutesPreferLongerOnes)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  *
  * @return vector with all possible predicted routes.
  */
-std::vector<route::FullRoute> predictRoutesOnDistance(const match::MapMatchedObjectBoundingBox &start,
-                                                      physics::Distance const &predictionDistance,
-                                                      RouteCreationMode const routeCreationMode
-                                                      = RouteCreationMode::SameDrivingDirection);
+std::vector<route::FullRoute>
+predictRoutesOnDistance(const match::MapMatchedObjectBoundingBox &start,
+                        physics::Distance const &predictionDistance,
+                        RouteCreationMode const routeCreationMode = RouteCreationMode::SameDrivingDirection,
+                        FilterDuplicatesMode const filterMode = FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+                        ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief perform route based prediction restricted by the prediction distance and duration.
@@ -341,14 +379,46 @@ std::vector<route::FullRoute> predictRoutesOnDistance(const match::MapMatchedObj
  * @param[in] predictionDistance distance when the prediction can be stopped.
  * @param[in] predictionDuration duration when the prediction can be stopped.
  * @param[in] routeCreationMode the mode of creating the route (default: RouteCreationMode::SameDrivingDirection)
+ * @param[in] filterMode the mode for filtering the routes (default: FilterDuplicatesMode::SubRoutesPreferLongerOnes)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  *
  * @return vector with all possible predicted routes.
  */
-std::vector<route::FullRoute> predictRoutes(const match::MapMatchedObjectBoundingBox &start,
-                                            physics::Distance const &predictionDistance,
-                                            physics::Duration const &predictionDuration,
-                                            RouteCreationMode const routeCreationMode
-                                            = RouteCreationMode::SameDrivingDirection);
+std::vector<route::FullRoute>
+predictRoutes(const match::MapMatchedObjectBoundingBox &start,
+              physics::Distance const &predictionDistance,
+              physics::Duration const &predictionDuration,
+              RouteCreationMode const routeCreationMode = RouteCreationMode::SameDrivingDirection,
+              FilterDuplicatesMode const filterMode = FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+              ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
+
+/**
+ * @brief perform route based prediction restricted by the prediction distance and duration.
+ * Note: Route predictions will not stop in the middle of an intersection.
+ *   They continue until the intersection is left again.
+ *
+ * This variant of route prediction allows to travel in either road directions.
+ * Therefore, the start orientation is irrelevant (considered to be RoutingDirection::DONT_CARE).
+ *
+ * @param[in] start start point as parametric point.
+ * @param[in] predictionDistance distance when the prediction can be stopped.
+ * @param[in] predictionDuration duration when the prediction can be stopped.
+ * @param[in] routeCreationMode the mode of creating the route (default: RouteCreationMode::AllRoutableLanes)
+ *  Be aware: selecting a routeCreationMode of RouteCreationMode::SameDrivingDirection will lead to incomplete
+ * FullRoutes
+ *  since the routes starting in wrong direction cannot be presented by this!
+ * @param[in] filterMode the mode for filtering the routes (default: FilterDuplicatesMode::SubRoutesPreferLongerOnes)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
+ *
+ * @return vector with all possible predicted routes.
+ */
+std::vector<route::FullRoute>
+predictRoutesDirectionless(const point::ParaPoint &start,
+                           physics::Distance const &predictionDistance,
+                           physics::Duration const &predictionDuration,
+                           RouteCreationMode const routeCreationMode = RouteCreationMode::AllRoutableLanes,
+                           FilterDuplicatesMode const filterMode = FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+                           ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief Filter duplicated routes from a list of routes
@@ -356,10 +426,49 @@ std::vector<route::FullRoute> predictRoutes(const match::MapMatchedObjectBoundin
  * If one of the routes is a real sub-route of the other, the longer version of the route is kept, the shorter dropped
  *
  * @param[in] fullRoutes list of full routes to be filtered
+ * @param[in] filterMode the mode for filtering the routes
  *
- * @returns the filtered list of routes
+ * @returns the filtered list of routes according to the provided \a filterMode
  */
-std::vector<FullRoute> filterDuplicatedRoutes(const std::vector<FullRoute> fullRoutes);
+FullRouteList filterDuplicatedRoutes(const FullRouteList fullRoutes, FilterDuplicatesMode const filterMode);
+
+/** @brief result for comparing two routes with each other
+ */
+enum class CompareRouteResult
+{
+  /**
+   * equal
+   */
+  Equal,
+  /**
+   * shorter
+   */
+  Shorter,
+  /**
+   * longer
+   */
+  Longer,
+  /**
+   * differ
+   */
+  Differ
+};
+
+std::ostream &operator<<(std::ostream &os, CompareRouteResult const &value);
+
+/**
+ * @brief Compare two routes on interval level
+ *
+ * @returns CompareRouteResult of the comparison
+ * @retval CompareRouteResult::Equal left route and right route are considered equal on interval level
+ * @retval CompareRouteResult::Shorter left route is a real sub-route of the right route, therefore left route is
+ * considered shorter
+ * @retval CompareRouteResult::Longer right route is a real sub-route of the left route, therefore left route is
+ * considered longer
+ * @retval CompareRouteResult::Differ left route and right route are considered different on interval level
+ *
+ */
+CompareRouteResult compareRoutesOnIntervalLevel(FullRoute const &left, FullRoute const &right);
 
 /**
  * @brief Calculate the connecting route between the the two objects
@@ -374,15 +483,16 @@ std::vector<FullRoute> filterDuplicatedRoutes(const std::vector<FullRoute> fullR
  * @param[in] maxDuration duration when the search can be stopped.
  * @param[in] startObjectPredictionHints route prediction hints for start object (optional)
  * @param[in] destObjectPredictionHints route prediction hints for dest object (optional)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  */
-ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
-                                         const match::Object &destObject,
-                                         physics::Distance const &maxDistance,
-                                         physics::Duration const &maxDuration,
-                                         std::vector<route::FullRoute> const &startObjectPredictionHints
-                                         = std::vector<route::FullRoute>(),
-                                         std::vector<route::FullRoute> const &destObjectPredictionHints
-                                         = std::vector<route::FullRoute>());
+ConnectingRoute calculateConnectingRoute(
+  const match::Object &startObject,
+  const match::Object &destObject,
+  physics::Distance const &maxDistance,
+  physics::Duration const &maxDuration,
+  std::vector<route::FullRoute> const &startObjectPredictionHints = std::vector<route::FullRoute>(),
+  std::vector<route::FullRoute> const &destObjectPredictionHints = std::vector<route::FullRoute>(),
+  ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief Calculate the connecting route between the the two objects
@@ -396,14 +506,15 @@ ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
  * @param[in] maxDistance distance when the search can be stopped.
  * @param[in] startObjectPredictionHints route prediction hints for start object (optional)
  * @param[in] destObjectPredictionHints route prediction hints for dest object (optional)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  */
-ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
-                                         const match::Object &destObject,
-                                         physics::Distance const &maxDistance,
-                                         std::vector<route::FullRoute> const &startObjectPredictionHints
-                                         = std::vector<route::FullRoute>(),
-                                         std::vector<route::FullRoute> const &destObjectPredictionHints
-                                         = std::vector<route::FullRoute>());
+ConnectingRoute calculateConnectingRoute(
+  const match::Object &startObject,
+  const match::Object &destObject,
+  physics::Distance const &maxDistance,
+  std::vector<route::FullRoute> const &startObjectPredictionHints = std::vector<route::FullRoute>(),
+  std::vector<route::FullRoute> const &destObjectPredictionHints = std::vector<route::FullRoute>(),
+  ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief Calculate the connecting route between the the two objects
@@ -417,14 +528,15 @@ ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
  * @param[in] maxDuration duration when the search can be stopped.
  * @param[in] startObjectPredictionHints route prediction hints for start object (optional)
  * @param[in] destObjectPredictionHints route prediction hints for dest object (optional)
+ * @param[in] relevantLanes if not empty, the function restricts the prediction to the given set of lanes
  */
-ConnectingRoute calculateConnectingRoute(const match::Object &startObject,
-                                         const match::Object &destObject,
-                                         physics::Duration const &maxDuration,
-                                         std::vector<route::FullRoute> const &startObjectPredictionHints
-                                         = std::vector<route::FullRoute>(),
-                                         std::vector<route::FullRoute> const &destObjectPredictionHints
-                                         = std::vector<route::FullRoute>());
+ConnectingRoute calculateConnectingRoute(
+  const match::Object &startObject,
+  const match::Object &destObject,
+  physics::Duration const &maxDuration,
+  std::vector<route::FullRoute> const &startObjectPredictionHints = std::vector<route::FullRoute>(),
+  std::vector<route::FullRoute> const &destObjectPredictionHints = std::vector<route::FullRoute>(),
+  ::ad::map::lane::LaneIdSet const &relevantLanes = ::ad::map::lane::LaneIdSet());
 
 /**
  * @brief update route planning counters of the route
@@ -438,7 +550,9 @@ void updateRoutePlanningCounters(route::FullRoute &route);
  *
  * mainly used internally.
  */
-FullRoute createFullRoute(const Route::RawRoute &rawRoute, RouteCreationMode const routeCreationMode);
+FullRoute createFullRoute(const Route::RawRoute &rawRoute,
+                          RouteCreationMode const routeCreationMode,
+                          lane::LaneIdSet const &relevantLanes);
 
 } // namespace planning
 } // namespace route

--- a/ad_map_access/impl/include/ad/map/route/Route.hpp
+++ b/ad_map_access/impl/include/ad/map/route/Route.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -14,11 +14,11 @@
 #include "ad/map/point/ParaPointList.hpp"
 #include "ad/map/route/Routing.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace route */
+/** @brief namespace route */
 namespace route {
 /**
  * @namespace planning
@@ -165,6 +165,14 @@ protected:
   ///< Calculated routes.
   std::vector<RawRoute> mRawRoutes;
 };
+
+inline std::ostream &operator<<(std::ostream &os, Route::RawRoute const &value)
+{
+  os << "Route::RawRoute("
+     << " routeDistance:" << value.routeDistance << " routeDuration:" << value.routeDuration
+     << " paraPoints:" << value.paraPointList << ")";
+  return os;
+}
 
 } // namespace planning
 } // namespace route

--- a/ad_map_access/impl/include/ad/map/route/RouteAStar.hpp
+++ b/ad_map_access/impl/include/ad/map/route/RouteAStar.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -12,11 +12,11 @@
 
 #include "ad/map/route/RouteExpander.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace route */
+/** @brief namespace route */
 namespace route {
 /**
  * @namespace planning

--- a/ad_map_access/impl/include/ad/map/route/RouteOperation.hpp
+++ b/ad_map_access/impl/include/ad/map/route/RouteOperation.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -16,9 +16,9 @@
 #include "ad/map/route/Types.hpp"
 #include "ad/physics/Types.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
 
 /** @brief namespace intersection */
@@ -29,7 +29,7 @@ namespace intersection {
 class Intersection;
 } // namespace intersection
 
-/* @brief namespace route */
+/** @brief namespace route */
 namespace route {
 
 /**
@@ -728,6 +728,7 @@ void appendLaneSegmentToRoute(route::LaneInterval const &laneInterval,
  * @param[in/out] route the route to check and to extend
  * @param[in] length the minimum length
  * @param[in/out] additionalRoutes additional routes in case of intersections on the extension
+ * @param[in] relevantLanes if not empty, the function restricts the extension to the given set of lanes
  *
  * @returns pair of bool and vector
  *
@@ -737,7 +738,8 @@ void appendLaneSegmentToRoute(route::LaneInterval const &laneInterval,
  */
 bool extendRouteToDistance(route::FullRoute &route,
                            physics::Distance const &length,
-                           route::FullRouteList &additionalRoutes);
+                           route::FullRouteList &additionalRoutes,
+                           lane::LaneIdSet const &relevantLanes = ad::map::lane::LaneIdSet());
 
 /**
  * @brief extends route with the given list of destinations
@@ -785,11 +787,13 @@ bool extendRouteToDestinations(route::FullRoute &route, const std::vector<point:
  * @param[in] laneInterval the new lane interval to be append
  * @param[in] laneOffset the lane offset of the new lane interval to be append
  * @param[in] route the route the interval has to be appended
+ * @param[in] relevantLanes if not empty, the function restricts the extension to the given set of lanes
  *
  */
 void appendRoadSegmentToRoute(route::LaneInterval const &laneInverval,
                               route::RouteLaneOffset const &laneOffset,
-                              route::FullRoute &route);
+                              route::FullRoute &route,
+                              lane::LaneIdSet const &relevantLanes);
 
 /**
  * @brief add an opposing lane segment to an existing (and not empty) road segment with at most the given length
@@ -840,7 +844,7 @@ route::FullRoute getRouteExpandedToOppositeLanes(route::FullRoute const &route);
  * @returns the input route expanded by all neighbor lanes
  *
  * Internally recreates the route by calling appendRoadSegmentToRoute()  with a new route
- * having RouteCreationMode::AllAllNeighbors
+ * having RouteCreationMode::AllNeighbors
  */
 route::FullRoute getRouteExpandedToAllNeighborLanes(route::FullRoute const &route);
 
@@ -856,7 +860,7 @@ route::FullRoute getRouteExpandedToAllNeighborLanes(route::FullRoute const &rout
  *
  * @return false if no valid bypassing route was found
  */
-bool calculateBypassingRoute(::ad::map::route::FullRoute const &route, ::ad::map::route::FullRoute &bypassingRoute);
+bool calculateBypassingRoute(route::FullRoute const &route, route::FullRoute &bypassingRoute);
 
 /** @brief get borders of a road segment. The road segment is cut at a given parametric offset.
  *

--- a/ad_map_access/impl/include/ad/map/route/RoutePrediction.hpp
+++ b/ad_map_access/impl/include/ad/map/route/RoutePrediction.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -13,11 +13,11 @@
 #include "ad/map/route/RouteExpander.hpp"
 #include "ad/map/route/Routing.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace route */
+/** @brief namespace route */
 namespace route {
 /**
  * @namespace planning
@@ -48,10 +48,12 @@ public:
    * @param[in] start Start point.
    * @param[in] predictionDistance maximum prediction distance.
    * @param[in] predictionDuration maximum prediction duration.
+   * @param[in] typ Type of the route to be calculated (default Route::Type::SHORTEST).
    */
   RoutePrediction(const RoutingParaPoint &start,
                   physics::Distance const &predictionDistance,
-                  physics::Duration const &predictionDuration);
+                  physics::Duration const &predictionDuration,
+                  Type typ = Route::Type::SHORTEST);
 
   /**
    * @brief Constructor.
@@ -62,8 +64,11 @@ public:
    *
    * @param[in] start Start point.
    * @param[in] predictionDistance maximum prediction distance.
+   * @param[in] typ Type of the route to be calculated (default Route::Type::SHORTEST).
    */
-  RoutePrediction(const RoutingParaPoint &start, physics::Distance const &predictionDistance);
+  RoutePrediction(const RoutingParaPoint &start,
+                  physics::Distance const &predictionDistance,
+                  Type typ = Route::Type::SHORTEST);
 
   /**
    * @brief Constructor.
@@ -74,8 +79,11 @@ public:
    *
    * @param[in] start Start point.
    * @param[in] predictionDuration maximum prediction duration.
+   * @param[in] typ Type of the route to be calculated (default Route::Type::SHORTEST).
    */
-  RoutePrediction(const RoutingParaPoint &start, physics::Duration const &predictionDuration);
+  RoutePrediction(const RoutingParaPoint &start,
+                  physics::Duration const &predictionDuration,
+                  Type typ = Route::Type::SHORTEST);
 
   /**
    * @brief Calculates the route predictions using breadth search algorithm.
@@ -91,6 +99,12 @@ private:
                    lane::Lane::ConstPtr neighborLane,
                    RoutingPoint const &neighbor,
                    ExpandReason const &expandReason) override;
+
+  /**
+   * @brief actually insert neighbor in data structures
+   */
+  void insertNeighbor(RoutingPoint const &origin, RoutingPoint const &neighbor);
+
   /**
    * @brief Element of the routing tree
    */

--- a/ad_map_access/impl/src/intersection/CoreIntersection.cpp
+++ b/ad_map_access/impl/src/intersection/CoreIntersection.cpp
@@ -1,0 +1,504 @@
+// ----------------- BEGIN LICENSE BLOCK ---------------------------------
+//
+// Copyright (C) 2018-2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+//
+// ----------------- END LICENSE BLOCK -----------------------------------
+
+#include "ad/map/intersection/CoreIntersection.hpp"
+
+#include "ad/map/access/Logging.hpp"
+#include "ad/map/lane/LaneOperation.hpp"
+#include "ad/map/match/AdMapMatching.hpp"
+#include "ad/map/route/RouteOperation.hpp"
+
+namespace ad {
+namespace map {
+namespace intersection {
+
+point::ParaPoint CoreIntersection::getEntryParaPointOfExternalLane(lane::LaneId const &laneId) const
+{
+  point::ParaPoint p;
+  p.laneId = laneId;
+  p.parametricOffset
+    = (lane::isLaneDirectionNegative(laneId) ? physics::ParametricValue(0.) : physics::ParametricValue(1.));
+  return p;
+}
+
+point::ParaPoint CoreIntersection::getExitParaPointOfExternalLane(lane::LaneId const &laneId) const
+{
+  point::ParaPoint p;
+  p.laneId = laneId;
+  p.parametricOffset
+    = (lane::isLaneDirectionNegative(laneId) ? physics::ParametricValue(1.) : physics::ParametricValue(0.));
+  return p;
+}
+
+point::ParaPoint CoreIntersection::getEntryParaPointOfInternalLane(lane::LaneId const &laneId) const
+{
+  // for internal lanes the para point logic is vice-versa to external lanes
+  return getExitParaPointOfExternalLane(laneId);
+}
+
+point::ParaPoint CoreIntersection::getExitParaPointOfInternalLane(lane::LaneId const &laneId) const
+{
+  // for internal lanes the para point logic is vice-versa to external lanes
+  return getEntryParaPointOfExternalLane(laneId);
+}
+
+bool CoreIntersection::isLanePartOfIntersection(lane::LaneId const laneId, SuccessorMode const successorMode) const
+{
+  if (successorMode == SuccessorMode::OwnIntersection)
+  {
+    return isLanePartOfCoreIntersection(laneId);
+  }
+  else
+  {
+    return isLanePartOfAnIntersection(laneId);
+  }
+}
+
+lane::LaneIdSet const &CoreIntersection::internalLanes() const
+{
+  return mInternalLanes;
+}
+
+lane::LaneIdSet const &CoreIntersection::entryLanes() const
+{
+  return mEntryLanes;
+}
+
+point::ParaPointList const &CoreIntersection::entryParaPoints() const
+{
+  return mEntryParaPoints;
+}
+
+lane::LaneIdSet const &CoreIntersection::exitLanes() const
+{
+  return mExitLanes;
+}
+
+point::ParaPointList const &CoreIntersection::exitParaPoints() const
+{
+  return mExitParaPoints;
+}
+
+bool CoreIntersection::isLanePartOfCoreIntersection(lane::LaneId const laneId) const
+{
+  return (mInternalLanes.find(laneId) != mInternalLanes.end());
+}
+
+void CoreIntersection::extractLanesOfCoreIntersection(lane::LaneId const laneId)
+{
+  if (isLanePartOfCoreIntersection(laneId))
+  {
+    return;
+  }
+  auto lane = lane::getLane(laneId);
+  if (!lane::isLanePartOfAnIntersection(lane))
+  {
+    // restrict ourselves to lanes inside the intersection
+    return;
+  }
+  mInternalLanes.insert(laneId);
+  if (mInternalLanes.size() == 1u)
+  {
+    mInternalLanesBoundingSphere = lane.boundingSphere;
+  }
+  else
+  {
+    mInternalLanesBoundingSphere = mInternalLanesBoundingSphere + lane.boundingSphere;
+  }
+  for (auto const &contact : lane.contactLanes)
+  {
+    processContactsForLane(lane, contact);
+    extractLanesOfCoreIntersection(contact.toLane);
+  }
+}
+
+void CoreIntersection::processContactsForLane(lane::Lane const &lane, lane::ContactLane const &contact)
+{
+  auto const &toId = contact.toLane;
+  switch (contact.location)
+  {
+    case lane::ContactLocation::OVERLAP:
+      mOverlapping[lane.id].insert(toId);
+      break;
+    case lane::ContactLocation::SUCCESSOR:
+      if (isLaneDirectionPositive(lane))
+      {
+        mSuccessor[lane.id].insert(toId);
+        checkAndInsertExitLane(toId);
+      }
+      else
+      {
+        mPredecessor[lane.id].insert(toId);
+        checkAndInsertEntryLane(toId);
+      }
+      break;
+    case lane::ContactLocation::PREDECESSOR:
+      if (isLaneDirectionNegative(lane))
+      {
+        mSuccessor[lane.id].insert(toId);
+        checkAndInsertExitLane(toId);
+      }
+      else
+      {
+        mPredecessor[lane.id].insert(toId);
+        checkAndInsertEntryLane(toId);
+      }
+      break;
+    default:
+      break; // ignored for now
+  }
+}
+
+void CoreIntersection::checkAndInsertEntryLane(lane::LaneId const laneId)
+{
+  if (!isLanePartOfAnIntersection(laneId))
+  {
+    if (mEntryLanes.insert(laneId).second)
+    {
+      mEntryParaPoints.push_back(getEntryParaPointOfExternalLane(laneId));
+    }
+  }
+}
+
+void CoreIntersection::checkAndInsertExitLane(lane::LaneId const laneId)
+{
+  if (!isLanePartOfAnIntersection(laneId))
+  {
+    if (mExitLanes.insert(laneId).second)
+    {
+      mExitParaPoints.push_back(getExitParaPointOfExternalLane(laneId));
+    }
+  }
+}
+
+std::pair<lane::LaneIdSet, lane::LaneIdSet>
+CoreIntersection::getDirectSuccessorsInLaneDirection(lane::LaneId const laneId, SuccessorMode const successorMode) const
+{
+  auto lane = lane::getLane(laneId);
+  auto location = lane::ContactLocation::SUCCESSOR;
+  if (lane.direction == lane::LaneDirection::NEGATIVE)
+  {
+    location = lane::ContactLocation::PREDECESSOR;
+  }
+  std::pair<lane::LaneIdSet, lane::LaneIdSet> result;
+  for (auto const &contact : lane::getContactLanes(lane, location))
+  {
+    lane::LaneId const successorLane = contact.toLane;
+    if (isLanePartOfIntersection(successorLane, successorMode))
+    {
+      // restrict first to within intersection
+      result.first.insert(successorLane);
+    }
+    else
+    {
+      // restrict second to outside intersection
+      result.second.insert(successorLane);
+    }
+  }
+  return result;
+}
+
+lane::LaneIdSet
+CoreIntersection::getDirectSuccessorsInLaneDirectionWithinIntersection(lane::LaneId const laneId,
+                                                                       SuccessorMode const successorMode) const
+{
+  return getDirectSuccessorsInLaneDirection(laneId, successorMode).first;
+}
+
+lane::LaneIdSet
+CoreIntersection::getAllSuccessorsInLaneDirectionWithinIntersection(lane::LaneId const laneId,
+                                                                    SuccessorMode const successorMode) const
+{
+  lane::LaneIdSet result;
+  auto directSuccessors = getDirectSuccessorsInLaneDirectionWithinIntersection(laneId, successorMode);
+  for (auto directSuccessorId : directSuccessors)
+  {
+    auto directSuccessorRecursiveResult
+      = getAllSuccessorsInLaneDirectionWithinIntersection(directSuccessorId, successorMode);
+    result.insert(directSuccessorRecursiveResult.begin(), directSuccessorRecursiveResult.end());
+  }
+  result.insert(directSuccessors.begin(), directSuccessors.end());
+  return result;
+}
+
+lane::LaneIdSet
+CoreIntersection::getLaneAndAllSuccessorsInLaneDirectionWithinIntersection(lane::LaneId const laneId,
+                                                                           SuccessorMode const successorMode) const
+{
+  auto result = getAllSuccessorsInLaneDirectionWithinIntersection(laneId, successorMode);
+  if (isLanePartOfIntersection(laneId, successorMode))
+  {
+    result.insert(laneId);
+  }
+  return result;
+}
+
+lane::LaneIdSet CoreIntersection::getAllReachableOutgoingLanes(lane::LaneId const laneId,
+                                                               SuccessorMode const successorMode) const
+{
+  lane::LaneIdSet result;
+  auto directSuccessors = getDirectSuccessorsInLaneDirection(laneId, successorMode);
+  // recursive until end of intersection
+  for (auto directSuccessorId : directSuccessors.first)
+  {
+    auto directSuccessorRecursiveResult = getAllReachableOutgoingLanes(directSuccessorId, successorMode);
+    result.insert(directSuccessorRecursiveResult.begin(), directSuccessorRecursiveResult.end());
+  }
+  result.insert(directSuccessors.second.begin(), directSuccessors.second.end());
+  return result;
+}
+
+std::pair<lane::LaneIdSet, lane::LaneIdSet>
+CoreIntersection::getAllReachableInternalAndOutgoingLanes(lane::LaneId const laneId,
+                                                          SuccessorMode const successorMode) const
+{
+  std::pair<lane::LaneIdSet, lane::LaneIdSet> result;
+  auto directSuccessors = getDirectSuccessorsInLaneDirection(laneId, successorMode);
+  // recursive until end of intersection
+  for (auto directSuccessorId : directSuccessors.first)
+  {
+    auto directSuccessorRecursiveResult = getAllReachableInternalAndOutgoingLanes(directSuccessorId, successorMode);
+    result.first.insert(directSuccessorRecursiveResult.first.begin(), directSuccessorRecursiveResult.first.end());
+    result.second.insert(directSuccessorRecursiveResult.second.begin(), directSuccessorRecursiveResult.second.end());
+  }
+  result.first.insert(directSuccessors.first.begin(), directSuccessors.first.end());
+  result.second.insert(directSuccessors.second.begin(), directSuccessors.second.end());
+  return result;
+}
+
+bool CoreIntersection::isLanePartOfAnIntersection(lane::LaneId const laneId)
+{
+  auto lane = lane::getLane(laneId);
+  return lane::isLanePartOfAnIntersection(lane);
+}
+
+bool CoreIntersection::isRoutePartOfAnIntersection(route::FullRoute const &route)
+{
+  for (auto const &roadSegment : route.roadSegments)
+  {
+    for (auto const &laneSegment : roadSegment.drivableLaneSegments)
+    {
+      if (isLanePartOfAnIntersection(laneSegment.laneInterval.laneId))
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool laneEntersIntersection(lane::LaneId const &from, lane::LaneId const &to)
+{
+  return ((from != to) && !CoreIntersection::isLanePartOfAnIntersection(from)
+          && CoreIntersection::isLanePartOfAnIntersection(to));
+}
+
+bool CoreIntersection::isRoadSegmentEnteringIntersection(
+  route::RouteIterator const &routeIterator, route::RoadSegmentList::const_iterator &routePreviousSegmentIter)
+{
+  if ((routeIterator.roadSegmentIterator != routeIterator.route.roadSegments.end())
+      && (routeIterator.roadSegmentIterator != routeIterator.route.roadSegments.begin()))
+  {
+    auto previousSegmentIter = routeIterator.roadSegmentIterator;
+    previousSegmentIter--;
+    // only look at the first parapoint per index
+    auto const fromLane = previousSegmentIter->drivableLaneSegments.front().laneInterval.laneId;
+    auto const toLane = routeIterator.roadSegmentIterator->drivableLaneSegments.front().laneInterval.laneId;
+    if (laneEntersIntersection(fromLane, toLane))
+    {
+      routePreviousSegmentIter = previousSegmentIter;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CoreIntersection::isIntersectionOnRoute(route::FullRoute const &route)
+{
+  for (auto roadSegmentIter = route.roadSegments.begin(); roadSegmentIter != route.roadSegments.end();
+       roadSegmentIter++)
+  {
+    route::RoadSegmentList::const_iterator routePreviousSegmentIter;
+    // @todo: also consider segments leaving intersection if first segment is already within intersection
+    if (isRoadSegmentEnteringIntersection(route::RouteIterator(route, roadSegmentIter), routePreviousSegmentIter))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CoreIntersection::objectWithinIntersection(match::MapMatchedObjectBoundingBox const &object) const
+{
+  for (auto const &occupiedLane : object.laneOccupiedRegions)
+  {
+    if (mInternalLanes.count(occupiedLane.laneId) > 0)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CoreIntersection::objectRouteCrossesIntersection(route::FullRoute const &objectRoute) const
+{
+  for (auto internalLaneId : mInternalLanes)
+  {
+    auto findResult = route::findWaypoint(internalLaneId, objectRoute);
+    if (findResult.isValid())
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+physics::Distance CoreIntersection::objectDistanceToIntersection(match::Object const &object) const
+{
+  physics::Distance minDistance = std::numeric_limits<physics::Distance>::max();
+  if (objectWithinIntersection(object.mapMatchedBoundingBox))
+  {
+    minDistance = physics::Distance(0.);
+  }
+  else
+  {
+    for (auto internalLaneId : mInternalLanes)
+    {
+      minDistance = std::min(minDistance, lane::getDistanceToLane(internalLaneId, object));
+    }
+  }
+  return minDistance;
+}
+
+CoreIntersection::CoreIntersection(lane::LaneId const &laneId)
+{
+  extractLanesOfCoreIntersection(laneId);
+}
+
+CoreIntersectionPtr CoreIntersection::getCoreIntersectionFor(lane::LaneId const &laneId)
+{
+  CoreIntersectionPtr result;
+  if (isLanePartOfAnIntersection(laneId))
+  {
+    result = CoreIntersectionPtr(new CoreIntersection(laneId));
+  }
+  return result;
+}
+
+template <typename CONTAINER>
+std::vector<CoreIntersectionPtr> CoreIntersection::getCoreIntersectionsForLaneIds(CONTAINER const &laneIds)
+{
+  std::vector<CoreIntersectionPtr> result;
+  for (auto &laneId : laneIds)
+  {
+    if (isLanePartOfAnIntersection(laneId))
+    {
+      bool createIntersection = true;
+      for (auto const &intersection : result)
+      {
+        auto const internalLanes = intersection->internalLanes();
+        if (internalLanes.find(laneId) != internalLanes.end())
+        {
+          createIntersection = false;
+          break;
+        }
+      }
+      if (createIntersection)
+      {
+        result.push_back(CoreIntersectionPtr(new CoreIntersection(laneId)));
+      }
+    }
+  }
+  return result;
+}
+
+std::vector<CoreIntersectionPtr> CoreIntersection::getCoreIntersectionsFor(lane::LaneIdSet const &laneIds)
+{
+  return getCoreIntersectionsForLaneIds(laneIds);
+}
+
+std::vector<CoreIntersectionPtr> CoreIntersection::getCoreIntersectionsFor(lane::LaneIdList const &laneIds)
+{
+  return getCoreIntersectionsForLaneIds(laneIds);
+}
+
+CoreIntersectionPtr CoreIntersection::getCoreIntersectionFor(match::MapMatchedPosition const &mapMatchedPosition)
+{
+  return CoreIntersection::getCoreIntersectionFor(mapMatchedPosition.lanePoint.paraPoint.laneId);
+}
+
+std::vector<CoreIntersectionPtr> CoreIntersection::getCoreIntersectionsForInLaneMatches(point::ENUPoint const &position)
+{
+  match::AdMapMatching mapMatching;
+  auto mapMatchedPositionConfidenceList = mapMatching.findLanes(toECEF(position), physics::Distance(2.));
+  return CoreIntersection::getCoreIntersectionsForInLaneMatches(mapMatchedPositionConfidenceList);
+}
+
+std::vector<CoreIntersectionPtr> CoreIntersection::getCoreIntersectionsForInLaneMatches(
+  match::MapMatchedPositionConfidenceList const &mapMatchedPositionConfidenceList)
+{
+  lane::LaneIdSet inLaneMatches;
+  for (auto const &mapMatchedPosition : mapMatchedPositionConfidenceList)
+  {
+    if (mapMatchedPosition.type == match::MapMatchedPositionType::LANE_IN)
+    {
+      inLaneMatches.insert(mapMatchedPosition.lanePoint.paraPoint.laneId);
+    }
+  }
+
+  return CoreIntersection::getCoreIntersectionsForLaneIds(inLaneMatches);
+}
+
+std::vector<CoreIntersectionPtr>
+CoreIntersection::getCoreIntersectionsForInLaneMatches(match::MapMatchedObjectBoundingBox const &object)
+{
+  lane::LaneIdSet inLaneMatches;
+  for (auto const &occupiedRegion : object.laneOccupiedRegions)
+  {
+    inLaneMatches.insert(occupiedRegion.laneId);
+  }
+
+  return CoreIntersection::getCoreIntersectionsForLaneIds(inLaneMatches);
+}
+
+std::vector<CoreIntersectionPtr> CoreIntersection::getCoreIntersectionsForMap()
+{
+  return getCoreIntersectionsFor(lane::getLanes());
+}
+
+} // namespace intersection
+} // namespace map
+} // namespace ad
+
+namespace std {
+
+std::ostream &operator<<(std::ostream &os, ::ad::map::intersection::CoreIntersection const &intersection)
+{
+  os << "CoreIntersection(";
+  os << " boundingSphere(center=" << ::ad::map::point::toENU(intersection.getBoundingSphere().center)
+     << ", radius=" << intersection.getBoundingSphere().radius << ")";
+  os << std::endl;
+  os << "->internalLanes: ";
+  os << intersection.internalLanes();
+  os << std::endl;
+  os << "->entryLanes: ";
+  os << intersection.entryLanes();
+  os << std::endl;
+  os << " -> entryParaPoints: ";
+  os << intersection.entryParaPoints();
+  os << std::endl;
+  os << " -> exitLanes: ";
+  os << intersection.exitLanes();
+  os << std::endl;
+  os << " -> exitParaPoints: ";
+  os << intersection.exitParaPoints();
+  os << ")" << std::endl;
+  return os;
+}
+
+} // namespace std

--- a/ad_map_access/impl/src/lane/LaneOperation.cpp
+++ b/ad_map_access/impl/src/lane/LaneOperation.cpp
@@ -804,6 +804,20 @@ LaneAltitudeRange calcLaneAltitudeRange(Lane const &lane)
   return altitude_range;
 }
 
+bool isLaneRelevantForExpansion(lane::LaneId const &laneId, lane::LaneIdSet const &relevantLanes)
+{
+  if (relevantLanes.empty())
+  {
+    return true;
+  }
+  auto const findResult = relevantLanes.find(laneId);
+  if (findResult != relevantLanes.end())
+  {
+    return true;
+  }
+  return false;
+}
+
 } // namespace lane
 } // namespace map
 } // namespace ad

--- a/ad_map_access/impl/src/route/RouteAStar.cpp
+++ b/ad_map_access/impl/src/route/RouteAStar.cpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -94,7 +94,23 @@ bool RouteAstar::calculate()
   // Initial values.
   RoutingCost cost;
   cost.costData.estimatedDistanceToTarget = costEstimate(mStartLane, mStart.point);
-  mProcessingMap.insert({mStart, cost});
+  if (mStart.direction == RoutingDirection::DONT_CARE)
+  {
+    // Don't care routing direction means the vehicle can drive forward or backward.
+    // Within the routing we have to replace this by concrete directions,
+    // otherwise the vehicle would be able to switch between forward/backward while driving on the route
+    // which especially is not meant by the don't care flag.
+    auto startPositive = mStart;
+    startPositive.direction = RoutingDirection::POSITIVE;
+    mProcessingMap.insert({startPositive, cost});
+    auto startNegative = mStart;
+    startNegative.direction = RoutingDirection::NEGATIVE;
+    mProcessingMap.insert({startNegative, cost});
+  }
+  else
+  {
+    mProcessingMap.insert({mStart, cost});
+  }
   // Run
   bool pathFound = false;
 #if DEBUG_OUTPUT

--- a/ad_map_access/impl/tests/intersection/IntersectionTests.cpp
+++ b/ad_map_access/impl/tests/intersection/IntersectionTests.cpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -69,6 +69,36 @@ struct IntersectionTest : ::testing::Test
     }
   }
 };
+
+TEST_F(IntersectionTest, create_core_intersection_all_way_stop_all)
+{
+  ASSERT_NO_THROW(::map_setup::prepareMapAllWayStop());
+  auto coreIntersections = ad::map::intersection::CoreIntersection::getCoreIntersectionsForMap();
+  ASSERT_EQ(1u, coreIntersections.size());
+}
+
+TEST_F(IntersectionTest, create_core_intersection_town01_all)
+{
+  ASSERT_NO_THROW(::map_setup::prepareMapTown01PrioRight());
+  auto coreIntersections = ad::map::intersection::CoreIntersection::getCoreIntersectionsForMap();
+  ASSERT_EQ(12u, coreIntersections.size());
+}
+
+TEST_F(IntersectionTest, create_core_intersection_town01_from_point_inside_intersection)
+{
+  ASSERT_NO_THROW(::map_setup::prepareMapTown01PrioRight());
+  auto coreIntersections = ad::map::intersection::CoreIntersection::getCoreIntersectionsForInLaneMatches(point::toENU(
+    point::createGeoPoint(point::Longitude(0.000815115), point::Latitude(0.0000102114), point::Altitude(0))));
+  ASSERT_EQ(1u, coreIntersections.size());
+}
+
+TEST_F(IntersectionTest, create_core_intersection_town01_from_point_outside_intersection)
+{
+  ASSERT_NO_THROW(::map_setup::prepareMapTown01PrioRight());
+  auto coreIntersections = ad::map::intersection::CoreIntersection::getCoreIntersectionsForInLaneMatches(point::toENU(
+    point::createGeoPoint(point::Longitude(0.0032321), point::Latitude(0.0000165612), point::Altitude(0))));
+  ASSERT_EQ(0u, coreIntersections.size());
+}
 
 TEST_F(IntersectionTest, create_intersections_all_way_stop)
 {
@@ -173,16 +203,16 @@ TEST_F(IntersectionTest, create_intersections_all_way_stop)
   resultParaPoints = intersection->outgoingParaPoints();
   expectedParaPoints.clear();
   paraPoint.laneId = lane::LaneId(272);
-  paraPoint.parametricOffset = physics::ParametricValue(0);
+  paraPoint.parametricOffset = physics::ParametricValue(1);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(256);
-  paraPoint.parametricOffset = physics::ParametricValue(0);
+  paraPoint.parametricOffset = physics::ParametricValue(1);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(260);
-  paraPoint.parametricOffset = physics::ParametricValue(1);
+  paraPoint.parametricOffset = physics::ParametricValue(0);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(244);
-  paraPoint.parametricOffset = physics::ParametricValue(1);
+  paraPoint.parametricOffset = physics::ParametricValue(0);
   expectedParaPoints.push_back(paraPoint);
   compareParaLists(resultParaPoints, expectedParaPoints);
 
@@ -376,19 +406,19 @@ TEST_F(IntersectionTest, traffic_lights_pfz_elf_to_rusch)
   resultParaPoints = intersection->outgoingParaPoints();
   expectedParaPoints.clear();
   paraPoint.laneId = lane::LaneId(508);
-  paraPoint.parametricOffset = physics::ParametricValue(1);
+  paraPoint.parametricOffset = physics::ParametricValue(0);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(627);
-  paraPoint.parametricOffset = physics::ParametricValue(0);
+  paraPoint.parametricOffset = physics::ParametricValue(1);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(548);
-  paraPoint.parametricOffset = physics::ParametricValue(1);
+  paraPoint.parametricOffset = physics::ParametricValue(0);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(471);
-  paraPoint.parametricOffset = physics::ParametricValue(1);
+  paraPoint.parametricOffset = physics::ParametricValue(0);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(630);
-  paraPoint.parametricOffset = physics::ParametricValue(0);
+  paraPoint.parametricOffset = physics::ParametricValue(1);
   expectedParaPoints.push_back(paraPoint);
   compareParaLists(resultParaPoints, expectedParaPoints);
 
@@ -560,19 +590,19 @@ TEST_F(IntersectionTest, traffic_lights_pfz_rusch_to_elf)
   resultParaPoints = intersection->outgoingParaPoints();
   expectedParaPoints.clear();
   paraPoint.laneId = lane::LaneId(627);
-  paraPoint.parametricOffset = physics::ParametricValue(0);
+  paraPoint.parametricOffset = physics::ParametricValue(1);
   expectedParaPoints.push_back(paraPoint);
   paraPoint.laneId = lane::LaneId(548);
-  paraPoint.parametricOffset = physics::ParametricValue(1);
-  expectedParaPoints.push_back(paraPoint);
-  paraPoint.laneId = lane::LaneId(471);
-  paraPoint.parametricOffset = physics::ParametricValue(1);
-  expectedParaPoints.push_back(paraPoint);
-  paraPoint.laneId = lane::LaneId(630);
   paraPoint.parametricOffset = physics::ParametricValue(0);
   expectedParaPoints.push_back(paraPoint);
-  paraPoint.laneId = lane::LaneId(508);
+  paraPoint.laneId = lane::LaneId(471);
+  paraPoint.parametricOffset = physics::ParametricValue(0);
+  expectedParaPoints.push_back(paraPoint);
+  paraPoint.laneId = lane::LaneId(630);
   paraPoint.parametricOffset = physics::ParametricValue(1);
+  expectedParaPoints.push_back(paraPoint);
+  paraPoint.laneId = lane::LaneId(508);
+  paraPoint.parametricOffset = physics::ParametricValue(0);
   expectedParaPoints.push_back(paraPoint);
   compareParaLists(resultParaPoints, expectedParaPoints);
 

--- a/ad_map_access/impl/tests/route/RoutePlanningTests.cpp
+++ b/ad_map_access/impl/tests/route/RoutePlanningTests.cpp
@@ -1,11 +1,12 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
 // ----------------- END LICENSE BLOCK -----------------------------------
 
+#include <ad/map/access/Logging.hpp>
 #include <ad/map/access/Operation.hpp>
 #include <ad/map/lane/Lane.hpp>
 #include <ad/map/lane/LaneOperation.hpp>
@@ -33,6 +34,7 @@ struct RoutePlanningTest : ::testing::Test
   virtual void SetUp()
   {
     access::cleanup();
+    // access::getLogger()->set_level(spdlog::level::trace);
   }
 
   virtual void TearDown()

--- a/ad_map_access/impl/tests/route/RoutePredictionTest.cpp
+++ b/ad_map_access/impl/tests/route/RoutePredictionTest.cpp
@@ -1,11 +1,12 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2019-2020 Intel Corporation
+// Copyright (C) 2019-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
 // ----------------- END LICENSE BLOCK -----------------------------------
 
+#include <ad/map/access/Logging.hpp>
 #include <ad/map/access/Operation.hpp>
 #include <ad/map/intersection/Intersection.hpp>
 #include <ad/map/match/Operation.hpp>
@@ -32,15 +33,9 @@ struct RoutePredictionTest : ::testing::Test
     {
       throw std::runtime_error("Unable to initialize with " + getTestMap());
     }
+    // access::getLogger()->set_level(spdlog::level::trace);
 
-    auto predictionStartGeo = getPredictionStartGeo();
-    ASSERT_TRUE(withinValidInputRange(predictionStartGeo));
-    match::AdMapMatching mapMatching;
-    auto mapMatchingResults
-      = mapMatching.getMapMatchedPositions(predictionStartGeo, physics::Distance(1.), physics::Probability(0.8));
-
-    ASSERT_GE(mapMatchingResults.size(), 1u);
-    predictionStart.point = mapMatchingResults.front().lanePoint.paraPoint;
+    getPredictionStartParaPoint(predictionStart.point);
     if (lane::isLaneDirectionPositive(lane::getLane(predictionStart.point.laneId)))
     {
       predictionStart.direction = route::planning::RoutingDirection::POSITIVE;
@@ -57,6 +52,18 @@ struct RoutePredictionTest : ::testing::Test
   }
 
   virtual std::string getTestMap() = 0;
+
+  virtual void getPredictionStartParaPoint(point::ParaPoint &predictionStartResult)
+  {
+    auto predictionStartGeo = getPredictionStartGeo();
+    ASSERT_TRUE(withinValidInputRange(predictionStartGeo));
+    match::AdMapMatching mapMatching;
+    auto mapMatchingResults
+      = mapMatching.getMapMatchedPositions(predictionStartGeo, physics::Distance(1.), physics::Probability(0.8));
+
+    ASSERT_GE(mapMatchingResults.size(), 1u);
+    predictionStartResult = mapMatchingResults.front().lanePoint.paraPoint;
+  }
 
   virtual point::GeoPoint getPredictionStartGeo()
   {
@@ -90,21 +97,99 @@ struct RoutePredictionTestTown03 : public RoutePredictionTest
 
 TEST_F(RoutePredictionTestTown01, route_prediction_positive)
 {
+  // remain in the same lane
   auto routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(10.));
-  EXPECT_EQ(routePredictions.size(), 1u);
+  ASSERT_EQ(routePredictions.size(), 1u);
+  ASSERT_EQ(1u, routePredictions[0].roadSegments.size());
+  point::ParaPoint expectedRouteEnd;
+  expectedRouteEnd.laneId = predictionStart.point.laneId;
+  expectedRouteEnd.parametricOffset = physics::ParametricValue(1.);
+  auto findWaypointResult = route::findNearestWaypoint({expectedRouteEnd}, routePredictions[0]);
+  EXPECT_TRUE(findWaypointResult.isValid());
 
-  routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(450.));
-  EXPECT_EQ(routePredictions.size(), 6u);
+  // the next crossing leads to a split of the route
+  routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(150.));
+  EXPECT_EQ(routePredictions.size(), 2u);
+}
+
+TEST_F(RoutePredictionTestTown01, route_prediction_negative)
+{
+  // since standing with wrong orientation, no prediction is available
+  predictionStart.direction = route::planning::RoutingDirection::NEGATIVE;
+  auto routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(10.));
+  ASSERT_EQ(routePredictions.size(), 0u);
+
+  // extending the search space doesn't help here
+  routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(150.));
+  ASSERT_EQ(routePredictions.size(), 0u);
 }
 
 TEST_F(RoutePredictionTestTown01, route_prediction_dont_care)
 {
+  // not knowing the start direction leads to the same result as positive here
   predictionStart.direction = route::planning::RoutingDirection::DONT_CARE;
   auto routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(10.));
-  EXPECT_EQ(routePredictions.size(), 1u);
+  ASSERT_EQ(routePredictions.size(), 1u);
+  ASSERT_EQ(1u, routePredictions[0].roadSegments.size());
+  point::ParaPoint expectedRouteEnd;
+  expectedRouteEnd.laneId = predictionStart.point.laneId;
+  expectedRouteEnd.parametricOffset = physics::ParametricValue(1.);
+  auto findWaypointResult = route::findNearestWaypoint({expectedRouteEnd}, routePredictions[0]);
+  EXPECT_TRUE(findWaypointResult.isValid());
 
-  routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(450.));
-  EXPECT_EQ(routePredictions.size(), 6u);
+  // the next crossing leads to a split of the route
+  routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(150.));
+  EXPECT_EQ(routePredictions.size(), 2u);
+}
+
+TEST_F(RoutePredictionTestTown01, route_prediction_directionless)
+{
+  // the directionless search allows to drive actually in both directions and change between lanes of different lane
+  // direction
+  auto routePredictions = route::planning::predictRoutesDirectionless(
+    predictionStart.point, physics::Distance(10.), physics::Duration(100.));
+  ASSERT_EQ(routePredictions.size(), 2u);
+  ASSERT_EQ(1u, routePredictions[0].roadSegments.size());
+  point::ParaPoint expectedRouteEnd;
+  expectedRouteEnd.laneId = predictionStart.point.laneId;
+  expectedRouteEnd.parametricOffset = physics::ParametricValue(1.);
+  auto findWaypointResult0 = route::findNearestWaypoint({expectedRouteEnd}, routePredictions[0]);
+  EXPECT_TRUE(findWaypointResult0.isValid());
+  ASSERT_EQ(1u, routePredictions[1].roadSegments.size());
+  expectedRouteEnd.parametricOffset = physics::ParametricValue(0.);
+  auto findWaypointResult1 = route::findNearestWaypoint({expectedRouteEnd}, routePredictions[1]);
+  EXPECT_TRUE(findWaypointResult1.isValid());
+
+  // the next crossing leads to a split of the each of the routes
+  routePredictions = route::planning::predictRoutesDirectionless(
+    predictionStart.point, physics::Distance(150.), physics::Duration(100.));
+  EXPECT_EQ(routePredictions.size(), 4u);
+}
+
+TEST_F(RoutePredictionTestTown01, route_prediction_relevant_lanes)
+{
+  // larger prediction distance to have two crossings and another split
+  auto routePredictions = route::planning::predictRoutesOnDistance(predictionStart, physics::Distance(300.));
+  ASSERT_EQ(routePredictions.size(), 3u);
+
+  // now we restrict the prediction to the lanes of and around the first intersection
+  ASSERT_GE(routePredictions[0].roadSegments.size(), 2u);
+  auto intersectionLaneId = routePredictions[0].roadSegments[1].drivableLaneSegments[0].laneInterval.laneId;
+  auto coreIntersection = intersection::CoreIntersection::getCoreIntersectionFor(intersectionLaneId);
+  ASSERT_NE(coreIntersection, nullptr);
+  auto relevantLanes = coreIntersection->internalLanes();
+  relevantLanes.insert(coreIntersection->entryLanes().begin(), coreIntersection->entryLanes().end());
+  relevantLanes.insert(coreIntersection->exitLanes().begin(), coreIntersection->exitLanes().end());
+
+  routePredictions
+    = route::planning::predictRoutesOnDistance(predictionStart,
+                                               physics::Distance(300.),
+                                               route::RouteCreationMode::SameDrivingDirection,
+                                               route::planning::FilterDuplicatesMode::SubRoutesPreferLongerOnes,
+                                               relevantLanes);
+  // as a result the second intersection is not existing anymore and the predictions stop,
+  // but the first intersection is still there, so one split is expected
+  ASSERT_EQ(routePredictions.size(), 2u);
 }
 
 TEST_F(RoutePredictionTestTown03, route_prediction_positive)
@@ -202,4 +287,29 @@ TEST_F(RoutePredictionTestRoundabout, route_prediction)
   // - circling just before out to east
   // the route towards the west is not present in the new map!
   EXPECT_EQ(routePredictions.size(), 3u);
+}
+
+struct RoutePredictionTestTown04 : public RoutePredictionTest
+{
+  void getPredictionStartParaPoint(point::ParaPoint &predictionStartResult) override
+  {
+    predictionStartResult.laneId = lane::LaneId(490148);
+    predictionStartResult.parametricOffset = physics::ParametricValue(0.1);
+  }
+
+  std::string getTestMap() override
+  {
+    return "test_files/Town04.txt";
+  }
+};
+
+TEST_F(RoutePredictionTestTown04, filter_duplicated_routes_multilane_not_algined)
+{
+  auto routePredictions
+    = route::planning::predictRoutesOnDistance(predictionStart,
+                                               physics::Distance(30),
+                                               RouteCreationMode::SameDrivingDirection,
+                                               planning::FilterDuplicatesMode::SubRoutesPreferShorterOnes);
+
+  EXPECT_EQ(1u, routePredictions.size());
 }

--- a/ad_map_access_test_support/impl/include/ad/map/test_support/ArtificialIntersectionTestBase.hpp
+++ b/ad_map_access_test_support/impl/include/ad/map/test_support/ArtificialIntersectionTestBase.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2019-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -10,11 +10,11 @@
 
 #include "ad/map/test_support/IntersectionTestBase.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace test_support */
+/** @brief namespace test_support */
 namespace test_support {
 
 /**

--- a/ad_map_access_test_support/impl/include/ad/map/test_support/IntersectionTestBase.hpp
+++ b/ad_map_access_test_support/impl/include/ad/map/test_support/IntersectionTestBase.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2019 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 //
@@ -12,13 +12,14 @@
 
 #include "ad/map/intersection/Intersection.hpp"
 
-/* @brief namespace ad */
+/** @brief namespace ad */
 namespace ad {
-/* @brief namespace map */
+/** @brief namespace map */
 namespace map {
-/* @brief namespace test_support */
+/** @brief namespace test_support */
 namespace test_support {
 
+/** @brief class supporting test creation */
 class IntersectionTestBase : public ::testing::Test
 {
 public:


### PR DESCRIPTION
Split CoreIntersection parts from Intersection wich are independant from
the route and right-of-way handling. And fixed outgoingParaPoints()

Extend map matching, route prediction and connecting route handling by
relevantLane parameter to restrict the functionality to a fixed subset
of the map.

Added route::planning::predictRoutesDirectionless().

Fix doxygen creation.

Fix filterDuplicateRoutes, calculateConnectingRoute

ade operation mode of route::planning::filterDuplicateRoutes() and all
of the route::planning::predictRoute*() functions configurable.

Fixed the search for start interval in
route::planning::compareRoutesOnIntervalLevel() and made function
public.

route::extendRouteToDistance() considers the shorter version of the
expanded routes instead of larger to prevent consecutive route
expansions to overlook possible routes through the intersection;

route::calculateConnectingRoute() considers not only the shortest
connecting route, but judges also the feasibility of the connecting
route based on the actual heading differences in respect to the route.
This prevents from selecting e.g. wrong 90° crossing lanes with very
small connecting route because vehicles would drive there side by side.

fixed route::calculateConnectingRouteCreateMergingRouteUpToPositions()
to actually shorten the routes by setting end interval to start of
inverval.

route::alignRoute{Ending|Starting}Points() prevent from invalid or
unnecesary alignments.

route: :planning::RouteAStar/RoutePrediction: handle
RoutingDirection: :DONT_CARE as input correctly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/map/70)
<!-- Reviewable:end -->
