### PR TITLE
Some CARLA 0.9.15+ adaptions

### DIFF
--- a/ad_map_access/generated/CMakeLists.txt
+++ b/ad_map_access/generated/CMakeLists.txt
@@ -34,7 +34,7 @@ if ((NOT ad_map_access_SOURCES) OR (NOT ad_map_access_INCLUDE_DIRS))
   message(FATAL_ERROR "${PROJECT_NAME}: Variable ad_map_access_SOURCES or ad_map_access_INCLUDE_DIRS pointing to the generator managed library not set!")
 endif()
 
-find_package(Boost REQUIRED COMPONENTS program_options filesystem)
+find_package(Boost 1.80 REQUIRED COMPONENTS program_options filesystem)
 get_target_property(BOOST_PROGRAM_OPTIONS_INTERFACE_INCLUDE_DIRS Boost::program_options INTERFACE_INCLUDE_DIRECTORIES)
 list(APPEND INCLUDE_DIRS ${BOOST_PROGRAM_OPTIONS_INTERFACE_INCLUDE_DIRS})
 list(APPEND LIBRARIES Boost::program_options)

--- a/ad_map_access/generated/cmake/Config.cmake.in
+++ b/ad_map_access/generated/cmake/Config.cmake.in
@@ -17,7 +17,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_package(Boost REQUIRED COMPONENTS program_options filesystem)
+find_package(Boost 1.80 REQUIRED COMPONENTS program_options filesystem)
 get_target_property(BOOST_PROGRAM_OPTIONS_INTERFACE_INCLUDE_DIRS Boost::program_options INTERFACE_INCLUDE_DIRECTORIES)
 list(APPEND INCLUDE_DIRS ${BOOST_PROGRAM_OPTIONS_INTERFACE_INCLUDE_DIRS})
 list(APPEND LIBRARIES Boost::program_options)

--- a/ad_map_opendrive_reader/CMakeLists.txt
+++ b/ad_map_opendrive_reader/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(${PROJECT_NAME} ${PROJECT_SOURCE_LIST})
 # dependencies
 #####################################################################
 
-find_package(Boost REQUIRED)
+find_package(Boost 1.80 REQUIRED)
 
 find_package(spdlog REQUIRED CONFIG)
 

--- a/ad_map_opendrive_reader/include/opendrive/geometry/Geometry.hpp
+++ b/ad_map_opendrive_reader/include/opendrive/geometry/Geometry.hpp
@@ -205,7 +205,7 @@ template <class T> double evalPoly3(std::set<T> const &sOffsetPoly3Set, double s
   }
   if (smallerOrEqual != sOffsetPoly3Set.end())
   {
-    auto poly = boost::array<double, 4>{{smallerOrEqual->a, smallerOrEqual->b, smallerOrEqual->c, smallerOrEqual->d}};
+    auto poly = std::array<double, 4>{{smallerOrEqual->a, smallerOrEqual->b, smallerOrEqual->c, smallerOrEqual->d}};
     return boost::math::tools::evaluate_polynomial(poly, s - smallerOrEqual->start_offset);
   }
   return 0.0;

--- a/ad_map_opendrive_reader/src/geometry/Geometry.cpp
+++ b/ad_map_opendrive_reader/src/geometry/Geometry.cpp
@@ -146,7 +146,7 @@ GeometryPoly3::GeometryPoly3(
 
 const DirectedPoint GeometryPoly3::PosFromDist(const double dist) const
 {
-  auto poly = boost::array<double, 4>{{_a, _b, _c, _d}};
+  auto poly = std::array<double, 4>{{_a, _b, _c, _d}};
 
   double u = dist;
   double v = boost::math::tools::evaluate_polynomial(poly, u);
@@ -161,7 +161,7 @@ const DirectedPoint GeometryPoly3::PosFromDist(const double dist) const
   double y = u * sin_t + v * cos_t;
   double z = 0.0;
 
-  auto tangentPoly = boost::array<double, 4>{{_b, 2.0 * _c, 3.0 * _d}};
+  auto tangentPoly = std::array<double, 4>{{_b, 2.0 * _c, 3.0 * _d}};
 
   double tangentV = boost::math::tools::evaluate_polynomial(tangentPoly, u);
   double theta = atan2(tangentV, 1.0);
@@ -204,8 +204,8 @@ const DirectedPoint GeometryParamPoly3::PosFromDist(const double dist) const
     p = std::min(1.0, dist / _length);
   }
 
-  auto polyU = boost::array<double, 4>{{_aU, _bU, _cU, _dU}};
-  auto polyV = boost::array<double, 4>{{_aV, _bV, _cV, _dV}};
+  auto polyU = std::array<double, 4>{{_aU, _bU, _cU, _dU}};
+  auto polyV = std::array<double, 4>{{_aV, _bV, _cV, _dV}};
 
   double u = boost::math::tools::evaluate_polynomial(polyU, p);
   double v = boost::math::tools::evaluate_polynomial(polyV, p);
@@ -219,8 +219,8 @@ const DirectedPoint GeometryParamPoly3::PosFromDist(const double dist) const
   double y = u * sin_t + v * cos_t;
   double z = 0.0;
 
-  auto tangentPolyU = boost::array<double, 4>{{_bU, 2.0 * _cU, 3.0 * _dU, 0.0}};
-  auto tangentPolyV = boost::array<double, 4>{{_bV, 2.0 * _cV, 3.0 * _dV, 0.0}};
+  auto tangentPolyU = std::array<double, 4>{{_bU, 2.0 * _cU, 3.0 * _dU, 0.0}};
+  auto tangentPolyV = std::array<double, 4>{{_bV, 2.0 * _cV, 3.0 * _dV, 0.0}};
 
   double tangentU = boost::math::tools::evaluate_polynomial(tangentPolyU, p);
   double tangentV = boost::math::tools::evaluate_polynomial(tangentPolyV, p);

--- a/cmake/python-binding.cmake
+++ b/cmake/python-binding.cmake
@@ -40,7 +40,7 @@ endfunction()
 
 function(find_python_binding_packages)
 
-  find_package(Boost REQUIRED)
+  find_package(Boost 1.80 REQUIRED)
   if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_GREATER 1.66)
     set(BOOST_PYTHON_SHORT_NAME ON)
   endif()
@@ -74,7 +74,7 @@ function(find_python_binding_packages)
       else()
         set(BOOST_COMPONENT_${BINDING_NAME} python-py${PYTHON_MAJ_MIN})
       endif()
-      find_package(Boost COMPONENTS REQUIRED ${BOOST_COMPONENT_${BINDING_NAME}})
+      find_package(Boost 1.80 COMPONENTS REQUIRED ${BOOST_COMPONENT_${BINDING_NAME}})
       message(STATUS "Found Boost version '${Boost_VERSION}' includes '${Boost_INCLUDE_DIRS}' link-target 'Boost::${BOOST_COMPONENT_${BINDING_NAME}}'\n: using Python includes '${PYTHON_INCLUDE_DIRS}' and lib '${PYTHON_LIBRARIES}'")
       list(APPEND LOCAL_PYTHON_BINDINGS ${BINDING_NAME})
       set(LOCAL_PYTHON_BINDING_PACKAGE_INCLUDE_DIRS_${BINDING_NAME}

--- a/cmake/python/python_wrapper_helper.py.in
+++ b/cmake/python/python_wrapper_helper.py.in
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # ----------------- BEGIN LICENSE BLOCK ---------------------------------
 #
-# Copyright (c) 2019-2020 Intel Corporation
+# Copyright (c) 2019-2022 Intel Corporation
 #
 # ----------------- END LICENSE BLOCK -----------------------------------
 
@@ -33,7 +33,7 @@ def get_list_of_files(directory, ignore_files):
             for ignore_file in ignore_files:
                 if full_path.find(ignore_file) != -1:
                     skip = True
-                    print ("Skipping file: " + full_path)
+                    print("Skipping file: " + full_path)
             if not skip:
                 if full_path.endswith(".h") or full_path.endswith(".hpp"):
                     all_files.append(full_path)
@@ -41,7 +41,7 @@ def get_list_of_files(directory, ignore_files):
     return all_files
 
 
-def generate_python_wrapper(header_directories, include_paths, library_name, cpp_filename, declarations, main_namespace="", ignore_declarations={}, ignore_files={}):
+def generate_python_wrapper(header_directories, include_paths, library_name, cpp_filename, declarations, main_namespace="", ignore_declarations={}, ignore_files={}, add_declarations={}):
     """
     Function to generate Python-C++ binding code by calling pygccxml and py++
 
@@ -60,6 +60,10 @@ def generate_python_wrapper(header_directories, include_paths, library_name, cpp
     :type ignore_declarations: list<string>
     :param ignore_files: a list of files to be ignored
     :type ignore_files: list<string>
+    :param add_declarations: a list of declarations to be explicitly enabled searched for in
+      against the full declaration string resulting from '"{}".format(decl)' output
+     (useful e.g. for typedefs to template types which are not as such visible in the delcarations)
+    :type add_declarations: list<string>
     :return:
     """
 
@@ -67,20 +71,19 @@ def generate_python_wrapper(header_directories, include_paths, library_name, cpp
 
     # Find out the xml generator (gccxml or castxml)
     generator_path, generator_name = utils.find_xml_generator()
-    compiler = "g++"
-    compiler_path = "/usr/bin/g++"
+    compiler = "@CXX@"
 
     # Create configuration for CastXML
     xml_generator_config = parser.xml_generator_configuration_t(
         xml_generator_path=generator_path,
         xml_generator=generator_name,
         compiler=compiler,
-        compiler_path=compiler_path,
         start_with_declarations=declarations)
 
     # Set include dirs and cflags to avoid warnings and errors
     xml_generator_config.append_cflags("-std=c++@CMAKE_CXX_STANDARD@")
     xml_generator_config.append_cflags("-Wno-error=invalid-constexpr")
+    xml_generator_config.append_cflags("-DSAFE_DATATYPES_EXPLICIT_CONVERSION=1")
 
     for inc_dir in include_paths:
         xml_generator_config.include_paths.append(inc_dir)
@@ -124,32 +127,57 @@ def generate_python_wrapper(header_directories, include_paths, library_name, cpp
             top_namespace, main_namespace))
 
     for decl in builder.decls():
+        decl_full_string_and_type = "{}".format(decl)
+        # print("declaration {} (alias {}, full {})".format(decl.name, decl.alias, decl_full_string_and_type))
+        if main_namespace != "":
+            if isinstance(decl, decl_wrappers.class_wrapper.class_t) or isinstance(decl, decl_wrappers.class_wrapper.class_declaration_t) or isinstance(decl, decl_wrappers.typedef_wrapper.typedef_t) or isinstance(decl, decl_wrappers.enumeration_wrapper.enumeration_t):
+                decl_full_string = decl_full_string_and_type.split(" ")[0]
+                if main_namespace in decl_full_string:
+                    # namespace present, ok
+                    # print("typedef/class/enum main namespace found [ignore-{},exposed-{}]:
+                    # {}".format(decl.ignore, decl.already_exposed,
+                    # decl_full_string_and_type))
+                    pass
+                elif decl_full_string in main_namespace:
+                    # declaration is a parent of main namespace, ok
+                    # print("typedef/class/enum declaration of upper level namespace found
+                    # [ignore{},exposed{}]: {}".format(decl.ignore, decl.already_exposed,
+                    # decl_full_string_and_type))
+                    pass
+                elif top_namespace != "" and not top_namespace in decl_full_string:
+                    # global or std defaults, ok
+                    # print("typedef/class/enum outside top namespace found
+                    # [ignore-{},exposed-{}]: {}".format(decl.ignore, decl.already_exposed,
+                    # decl_full_string_and_type))
+                    pass
+                else:
+                    # print("typedef/class/enum outside of main namespace found
+                    # [ignore-{},exposed-{}]. Ignoring: {}".format(decl.ignore,
+                    # decl.already_exposed, decl_full_string_and_type))
+                    decl.exclude()
+                    decl.ignore = True
+                    # try to enforce that it's not exported anymore
+                    decl.already_exposed = True
+
+                if decl.ignore:
+                    if decl_full_string in declarations:
+                        decl.ignore = False
+                        decl.already_exposed = False
+                        # print("Ignored typedef/class/enum explicitly listed in delclarations
+                        # found. Reenable {}".format(decl_full_string_and_type))
+                    for add_declaration in add_declarations:
+                        if (add_declaration in decl.name) or (add_declaration in decl.alias) or (add_declaration in decl_full_string_and_type):
+                            decl.ignore = False
+                            decl.already_exposed = False
+                            # print("declaration to explicitly add found: {} (alias {})".format(decl, decl.alias))
+                            break
         for ignore_declaration in ignore_declarations:
-            if ignore_declaration in decl.name or ignore_declaration in decl.alias:
+            if (ignore_declaration in decl.name) or (ignore_declaration in decl.alias) or (ignore_declaration in decl_full_string_and_type):
                 decl.exclude()
                 decl.ignore = True
                 decl.already_exposed = True
                 # print("declaration to ignore found: {} (alias {})".format(decl, decl.alias))
                 break
-        if main_namespace != "":
-            if isinstance(decl, decl_wrappers.class_wrapper.class_t) or isinstance(decl, decl_wrappers.class_wrapper.class_declaration_t) or isinstance(decl, decl_wrappers.typedef_wrapper.typedef_t):
-                decl_full_string = "{}".format(decl)
-                if main_namespace in decl_full_string:
-                    # namespace present, ok
-                    # print("typedef/class main namespace found: {}".format(decl_full_string))
-                    continue
-                if decl_full_string in main_namespace:
-                    # declaration is a parent of main namespace, ok
-                    # print("typedef/class declaration of upper level namespace found: {}".format(decl_full_string))
-                    continue
-                if top_namespace != "" and not top_namespace in decl_full_string:
-                    # global or std defaults, ok
-                    # print("typedef/class outside top namespace found: {}".format(decl_full_string))
-                    continue
-                # print("typedef/class outside of main namespace found. Ignoring: {}".format(decl_full_string))
-                decl.exclude()
-                decl.ignore = True
-                decl.already_exposed = True
 
     # debug declarations
     # builder.print_declarations()
@@ -168,7 +196,7 @@ def generate_python_wrapper(header_directories, include_paths, library_name, cpp
     print("generate_python_wrapper(): {} written.".format(cpp_filename))
 
 
-def post_process_python_wrapper(header_directories, cpp_filename_in, cpp_filename_out, additional_replacements={}, additional_includes={}, spdx_license="MIT", fix_include_directives=True, fix_enum_class=True):
+def post_process_python_wrapper(header_directories, cpp_filename_in, cpp_filename_out, additional_replacements=[], additional_includes={}, spdx_license="MIT", fix_include_directives=True, fix_enum_class=True):
     """
     Post process generated binding code
 
@@ -204,7 +232,7 @@ def post_process_python_wrapper(header_directories, cpp_filename_in, cpp_filenam
             file_output.write("/*\n"
                               " * ----------------- BEGIN LICENSE BLOCK ---------------------------------\n"
                               " *\n"
-                              " * Copyright (c) 2020 Intel Corporation\n"
+                              " * Copyright (c) 2020-2021 Intel Corporation\n"
                               " *\n"
                               " * SPDX-License-Identifier: " + spdx_license + "\n"
                               " *\n"
@@ -228,7 +256,7 @@ def post_process_python_wrapper(header_directories, cpp_filename_in, cpp_filenam
             for header_dir in header_directories:
                 if not header_dir.endswith("/"):
                     header_dir = header_dir + "/"
-                line = line.replace(header_dir, "")
+                line = str.replace(line, header_dir, "")
 
         # Fix C++ enum classes
         if fix_enum_class:
@@ -236,7 +264,7 @@ def post_process_python_wrapper(header_directories, cpp_filename_in, cpp_filenam
                 if line.find("export_values()") != -1:
                     enum_started = False
                 else:
-                    line = line.replace(enum_namespace, enum_namespace_full)
+                    line = str.replace(line, enum_namespace, enum_namespace_full)
             else:
                 match = enum_declaration_start.match(line)
                 if match:
@@ -246,7 +274,7 @@ def post_process_python_wrapper(header_directories, cpp_filename_in, cpp_filenam
                     enum_namespace_full = match.group(1) + "::"
 
         for replacement in additional_replacements:
-            line = line.replace(replacement[0], replacement[1])
+            line = str.replace(line, replacement[0], replacement[1])
 
         file_output.write(line)
 

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -9,3 +9,6 @@ list(APPEND TARGET_COMPILE_OPTIONS -Wall -Wextra -pedantic -Wfloat-equal -Wshado
 
 # treat warnings as errors
 list(APPEND TARGET_COMPILE_OPTIONS $<$<NOT:$<BOOL:${DISABLE_WARNINGS_AS_ERRORS}>>:-Werror>)
+
+# disable some warnings on 3rd party code
+list(APPEND TARGET_COMPILE_OPTIONS -Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations)

--- a/tools/map_maker/common/CMakeLists.txt
+++ b/tools/map_maker/common/CMakeLists.txt
@@ -9,7 +9,7 @@
 #####################################################################
 # MapMaker - Common - library
 #####################################################################
-find_package(Boost COMPONENTS REQUIRED
+find_package(Boost 1.80 COMPONENTS REQUIRED
   program_options
   system
   filesystem


### PR DESCRIPTION
Use Boost 1.80
generate_python_wrapper: Allow passing of CXX from outside warnings.cmake: Disable some clang-19 warnings on boost includes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/map/133)
<!-- Reviewable:end -->
