### PR TITLE
Change Dependabot update schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: docker
     directory: /.github/workflows/wheels/docker
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: pip
     directory: /doc
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
Updated Dependabot configuration to change update intervals to weekly for GitHub Actions, Docker, and pip packages.

And group codeql actions to ensure all versions are updated at once from now on

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/map/233)
<!-- Reviewable:end -->
